### PR TITLE
Sidebar basic structure update

### DIFF
--- a/home/templates/tags/side_menu.html
+++ b/home/templates/tags/side_menu.html
@@ -1,5 +1,4 @@
 {% load side_menu wagtailcore_tags static %}
-{% get_site_root as site_root %}
 
 <div class="mobile-sidemenu">
   <button class="mobile-sidemenu__toggle">Menu</button>

--- a/home/templates/tags/top_menu.html
+++ b/home/templates/tags/top_menu.html
@@ -1,5 +1,4 @@
 {% load top_menu wagtailcore_tags static %}
-{% get_site_root as site_root %}
 
 <header class='header'>
 

--- a/home/templatetags/side_menu.py
+++ b/home/templatetags/side_menu.py
@@ -12,8 +12,6 @@ register = template.Library()
 @register.assignment_tag(takes_context=True)
 def needs_sidebar(context):
     """ Checks if the page is an AbstractProgram descendant """
-    # print(dir(context['self']))
-    print(context['self'].get_parent())
     use_side_bar = False
     if isinstance(context['self'], AbstractProgram):
         use_side_bar = True

--- a/home/templatetags/side_menu.py
+++ b/home/templatetags/side_menu.py
@@ -2,20 +2,26 @@ from datetime import date
 from django import template
 from django.conf import settings
 
-from programs.models import Program
+from programs.models import Program, AbstractProgram
+from event.models import AllEventsHomePage
+from home.models import Post
 
 register = template.Library()
 
+
 @register.assignment_tag(takes_context=True)
-def get_site_root(context):
-    # NB this returns a core.Page, not the implementation-specific model used
-    # so object-comparison to self will return false as objects would differ
-    return context['request'].site.root_page
-
-
-# def has_menu_children(page):
-#     return page.get_children().live().in_menu().exists()
-
+def needs_sidebar(context):
+    """ Checks if the page is an AbstractProgram descendant """
+    # print(dir(context['self']))
+    print(context['self'].get_parent())
+    use_side_bar = False
+    if isinstance(context['self'], AbstractProgram):
+        use_side_bar = True
+    elif isinstance(context['self'], Post):
+        use_side_bar = True
+    elif 'programs.Program' in context['self'].parent_page_types:
+        use_side_bar = True
+    return use_side_bar
 
 # Retrieves the top menu items - the immediate children of the parent page
 @register.inclusion_tag('tags/side_menu.html', takes_context=True)
@@ -29,13 +35,14 @@ def side_menu(context, parent, calling_page=None):
     #         location_programs.append(program)
     #     else:
     #         programs.append(program)
-    return {
-        'calling_page': calling_page,
-        # 'programs': programs,
-        # 'location_programs': location_programs,
-        # required by the pageurl tag that we want to use within this template
-        'request': context['request'],
-    }
+    # return {
+    #     'calling_page': calling_page,
+    #     # 'programs': programs,
+    #     # 'location_programs': location_programs,
+    #     # required by the pageurl tag that we want to use within this template
+    #     'request': context['request'],
+    # }
+    return {}
 
 
 # Retrieves the children of the top menu items for the drop downs

--- a/home/templatetags/top_menu.py
+++ b/home/templatetags/top_menu.py
@@ -23,8 +23,6 @@ def top_menu(context, parent, calling_page=None):
     # programs = Program.objects.in_menu().order_by("title").exclude(location=True)
     programs = []
     location_programs = []
-    print parent
-    print calling_page
     all_programs = Program.objects.in_menu().order_by("title")
     for program in all_programs:
         if program.location == True:

--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -1,7 +1,7 @@
 {% load static wagtailuserbar %}
 {% load top_menu %}
 {% load side_menu %}
-{% load wagtailcore_tags %} 
+{% load wagtailcore_tags %}
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
@@ -48,22 +48,23 @@
 
                     </ul>
                 {% endif %}
-                
+                {% needs_sidebar as use_sidebar %}
+
                 <section class='section section--fixed-width'>
                     <div class='row'>
+                        {% if use_sidebar %}
                         <div class='sidebar-container'>
-                            {% if self.name != 'New America' %}
-                                {% block side_menu %}
-                                    {% get_site_root as site_root %}
-                                    {% side_menu parent=site_root calling_page=self %}
-                                {% endblock %}
-                            {% endif %}
+                            {% block side_menu %}
+                                {% side_menu parent=site_root calling_page=self %}
+                            {% endblock %}
                         </div>
-                        <div class='content-container'>
+                        {% endif %}
+                         <div class='content-container'>
                             {% block content %}
                             {% endblock %}
                         </div>
                     </div>
+
                 </section>
 
                 {% include 'ui_elements/footer.html' %}

--- a/press_release/models.py
+++ b/press_release/models.py
@@ -29,13 +29,14 @@ class PressRelease(Post):
     	FieldPanel('headline'),
     	FieldPanel('sub_headline'),
     	StreamFieldPanel('attachment'),
-    ] + Post.content_panels 
+    ] + Post.content_panels
+
 
 class AllPressReleasesHomePage(Page):
 	"""
 	A page which inherits from the abstract Page model and
 	returns every Press Release in the PressRelease model
-	for the organization-wide Press Release Homepage 
+	for the organization-wide Press Release Homepage
 	"""
 	parent_page_types = ['home.Homepage']
 	subpage_types = []
@@ -48,6 +49,7 @@ class AllPressReleasesHomePage(Page):
 
 	class Meta:
 		verbose_name = "Homepage for all Press Releases"
+
 
 class ProgramPressReleasesPage(Page):
 	"""


### PR DESCRIPTION
Hey @kjacks, I like where you're headed with this. On my machine, the sidebar menu was showing up on the homepage so this PR updates some of the logic to generate the sidebar menu only where appropriate. It should be working correctly except for org-wide events, which will require a significant refactor of the Events model. I'll tackle that sometime tomorrow or early next week.

Also just a heads up, I had to change the HTML structure in the `base.html` in order to include the side_bar logic and keep the content block available at all times. The CSS looked a bit funky after those changes so I think we'll need to figure out a solution. Let's touch base tomorrow!

If these changes look good, merge my PR into your branch on Github. Then in the terminal: 
```bash
git checkout sidebar-basic-structure
git pull origin sidebar-basic-structure
```