### PR TITLE
Post byline multiple authors

### DIFF
--- a/blog/templates/blog/blog_post.html
+++ b/blog/templates/blog/blog_post.html
@@ -10,6 +10,12 @@
 
 {% endblock %}
 
+{% block byline-prefix %}
+
+	By 
+
+{% endblock %}
+
 {% block post-body %}
 
     <div class="post-body">

--- a/blog/templates/blog/blog_post.html
+++ b/blog/templates/blog/blog_post.html
@@ -1,18 +1,19 @@
-{% extends "program_base.html" %}
+{% extends "post_page.html" %}
 
 {% load wagtailcore_tags %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% block body_class %}template-blogpost{% endblock %}
 
-{% block content %}
-    <h1>{{ page.title }}</h1>
-    <h2> {{page.date}}</h2>
-	    {% for author in authors %} 
-	    	<a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>
-	    	<br>
-	    {% endfor %}
 
-    <p> {{ page.body }} </p>
+{% block post-header %}
+
+{% endblock %}
+
+{% block post-body %}
+
+    <div class="post-body">
+	    {{ page.body }}
+	</div>
 
 {% endblock %}

--- a/book/templates/book/book.html
+++ b/book/templates/book/book.html
@@ -25,6 +25,15 @@
 
 {% endblock %}
 
+{% block byline-prefix %}
+
+	{% if authors|length > 1 %}
+		Authors:
+	{% else %}
+		Author:
+	{% endif %}
+
+{% endblock %}
 
 {% block post-body %}
 

--- a/book/templates/book/book.html
+++ b/book/templates/book/book.html
@@ -5,7 +5,7 @@
 
 {% block body_class %}template-book{% endblock %}
 
-{% block post-content %}
+{% block post-header %}
 	{% image page.story_image original as story_image %}
 
 	<div class="post-header">
@@ -23,24 +23,13 @@
 		</div>
 	</div>
 
-	<div class="post-container">
+{% endblock %}
 
-	    {% if page.post_author.all %}
-		    	
-		    <h5 class="post-author">Author: 
-				{% for author in authors %}
-					<a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>
-				{% endfor %}
-			</h5>
-			
-		{% endif %}
 
-	    <h5 class="post-date"> {{ page.date }} </h5>
+{% block post-body %}
 
-	    <div class="post-body">
-		    {{ page.body }}
-		</div>
-
+    <div class="post-body">
+	    {{ page.body }}
 	</div>
 
 {% endblock %}

--- a/home/templatetags/utilities.py
+++ b/home/templatetags/utilities.py
@@ -1,0 +1,16 @@
+from datetime import date
+from django import template
+from django.conf import settings
+
+from programs.models import Program
+
+register = template.Library()
+
+@register.simple_tag()
+def listify(i):
+	if i >= 2:
+		return ","
+	elif i == 1:
+		return " and"
+	else:
+		return ""

--- a/mysite/assets/scss/components/_post-body.scss
+++ b/mysite/assets/scss/components/_post-body.scss
@@ -89,9 +89,15 @@
 }
 
 .post-author {
+  color: palette-get(na-black);
   margin-top: 8px;
   font-size: 16px;
   font-weight:bold;
+
+  p {
+
+    display:inline-block;
+  }
 }
 
 .post-date {

--- a/mysite/assets/scss/components/_post-body.scss
+++ b/mysite/assets/scss/components/_post-body.scss
@@ -95,7 +95,7 @@
   font-weight:bold;
 
   p {
-
+    margin: 0px;
     display:inline-block;
   }
 }

--- a/mysite/assets/scss/components/_social-icons.scss
+++ b/mysite/assets/scss/components/_social-icons.scss
@@ -3,13 +3,23 @@
   padding: 0px;
 
   svg {
-    opacity: 0.3;
+    opacity: 1;
 
     &:hover {
       opacity: 1;
       -webkit-transition: 0.4s;
       transition: 0.4s;
+
+      .cls-1 {
+        fill: palette-get(na-black);
+        opacity: 1;
+      }
     }
+  }
+
+  .cls-1 {
+    fill: palette-get(na-black-40);
+    opacity: 1;
   }
 
   svg#facebook-icon {
@@ -39,5 +49,7 @@
   .st0 {
     fill: #2C2F35;
   }
+
+  
 
 }

--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -34,12 +34,13 @@
                         {% get_site_root as site_root %}
                         {% top_menu parent=site_root calling_page=self %}
                     {% endblock %}
-                </div> 
+                </div>
+
                 <section class='section section--fixed-width'>
 
                     <div class="container">
                         {% block sidebar %}
-                            <div class='content-container'>
+                        <div class='content-container'>
                         {% endblock %}
                             {% if self.get_ancestors|length > 2 %}
                             <div class='breadcrumb-social-media-container row'>

--- a/mysite/templates/post_page.html
+++ b/mysite/templates/post_page.html
@@ -2,6 +2,7 @@
 
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
+{% load utilities %}
 
 {% block body_class %}template-postpage{% endblock %}
 
@@ -19,13 +20,9 @@
 				{% endblock %}
 				
 				{% for author in authors %}
-					{% if forloop.revcounter0 >= 2 %}
-						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>,</p>
-					{% elif forloop.revcounter0 == 1 %}
-						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a> and</p>
-					{% else %}	
-						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a></p>
-					{% endif %}	
+					
+						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>{% listify forloop.revcounter0 %}</p>
+					
 				{% endfor %}
 			</h5>
 			

--- a/mysite/templates/post_page.html
+++ b/mysite/templates/post_page.html
@@ -9,8 +9,38 @@
 
 {% block content %}
 
-	{% block post-content %}
+	{% block post-header %}
 	{% endblock %}
+
+	<div class="post-container">
+
+	    {% if page.post_author.all %}
+		    	
+		    <h5 class="post-author">
+		    	{% if authors|length > 1 %}
+		    		Authors:
+		    	{% else %}
+		    		Author:
+		    	{% endif %}
+				{% for author in authors %}
+					{% if forloop.revcounter0 >= 2 %}
+						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>,</p>
+					{% elif forloop.revcounter0 == 1 %}
+						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a> and</p>
+					{% else %}	
+						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a></p>
+					{% endif %}	
+				{% endfor %}
+			</h5>
+			
+		{% endif %}
+
+		<h5 class="post-date">{{ page.date }}</h5>
+
+		{% block post-body %}
+		{% endblock %}
+
+	</div>
 
 	<div class='row border-panel-container'>
 		{% if page.post_author.all %}

--- a/mysite/templates/post_page.html
+++ b/mysite/templates/post_page.html
@@ -14,7 +14,10 @@
 
 	    {% if page.post_author.all %}
 		    	
-		    <h5 class="post-author">By 
+		    <h5 class="post-author">
+		    	{% block byline-prefix %}
+				{% endblock %}
+				
 				{% for author in authors %}
 					{% if forloop.revcounter0 >= 2 %}
 						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>,</p>

--- a/mysite/templates/post_page.html
+++ b/mysite/templates/post_page.html
@@ -5,11 +5,12 @@
 
 {% block body_class %}template-postpage{% endblock %}
 
+
+
 {% block content %}
 
-    {% block post-content %}
-
-    {% endblock %}
+	{% block post-content %}
+	{% endblock %}
 
 	<div class='row border-panel-container'>
 		{% if page.post_author.all %}
@@ -61,7 +62,7 @@
 					<div class='border-panel__content'>
 						
 							<p class= "border-panel__content__subscribe-info">Get our weekly digital magazine and events lineup in your inbox</p>
-							<input type='text' placeholder='Your Email' id='border-panel__content__email-field'></input>
+							<input type='text' placeholder='Your Email' id='border-panel__content__email-field'>
 							<button class='button' id='border-panel__content__link'>Sign up</button>
 						
 					</div>

--- a/mysite/templates/post_page.html
+++ b/mysite/templates/post_page.html
@@ -5,8 +5,6 @@
 
 {% block body_class %}template-postpage{% endblock %}
 
-
-
 {% block content %}
 
 	{% block post-header %}
@@ -16,12 +14,7 @@
 
 	    {% if page.post_author.all %}
 		    	
-		    <h5 class="post-author">
-		    	{% if authors|length > 1 %}
-		    		Authors:
-		    	{% else %}
-		    		Author:
-		    	{% endif %}
+		    <h5 class="post-author">By 
 				{% for author in authors %}
 					{% if forloop.revcounter0 >= 2 %}
 						<p><a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>,</p>

--- a/podcast/templates/podcast/podcast.html
+++ b/podcast/templates/podcast/podcast.html
@@ -5,7 +5,7 @@
 
 {% block body_class %}template-podcast{% endblock %}
 
-{% block post-content %}
+{% block post-header %}
 	{% image page.story_image original as story_image %}
 
 	{% if story_image %}
@@ -34,29 +34,18 @@
 
 	{% endif %}
 
-	<div class="post-container">
+	<div class="post-soundcloud">
+		<div class="post-soundcloud__logo"></div>
+    	{{ page.soundcloud }}
+    </div>
 
-		<div class="post-soundcloud">
-			<div class="post-soundcloud__logo"></div>
-	    	{{ page.soundcloud }}
-	    </div>
+{% endblock %}
 
-		{% if page.post_author.all %}
-		    	
-		    <h5 class="post-author">By 
-				{% for author in authors %}
-					<a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>
-				{% endfor %}
-			</h5>
-			
-		{% endif %}
+{% block post-body %}
 
-	    <h5 class="post-date"> {{ page.date }} </h5>
-
-	    <div class="post-body">
-		    {{ page.body }}
-		</div>
-
+    <div class="post-body">
+	    {{ page.body }}
 	</div>
+
 
 {% endblock %}

--- a/podcast/templates/podcast/podcast.html
+++ b/podcast/templates/podcast/podcast.html
@@ -41,11 +41,20 @@
 
 {% endblock %}
 
+{% block byline-prefix %}
+
+	{% if authors|length > 1 %}
+		Hosts:
+	{% else %}
+		Host:
+	{% endif %}
+
+{% endblock %}
+
 {% block post-body %}
 
     <div class="post-body">
 	    {{ page.body }}
 	</div>
-
 
 {% endblock %}

--- a/policy_paper/templates/policy_paper/policy_paper.html
+++ b/policy_paper/templates/policy_paper/policy_paper.html
@@ -25,6 +25,16 @@
 
 {% endblock %}
 
+{% block byline-prefix %}
+
+	{% if authors|length > 1 %}
+		Authors:
+	{% else %}
+		Author:
+	{% endif %}
+
+{% endblock %}
+
 {% block post-body %}
 
     <div class="post-body">

--- a/policy_paper/templates/policy_paper/policy_paper.html
+++ b/policy_paper/templates/policy_paper/policy_paper.html
@@ -5,7 +5,7 @@
 
 {% block body_class %}template-policypaper{% endblock %}
 
-{% block post-content %}
+{% block post-header %}
 	{% image page.story_image original as story_image %}
 
 	<div class="post-header">
@@ -23,33 +23,21 @@
 		</div>
 	</div>
 
-	<div class="post-container">
+{% endblock %}
 
-		{% if page.post_author.all %}
-		    	
-		    <h5 class="post-author">Author: 
-				{% for author in authors %}
-					<a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>
-				{% endfor %}
-			</h5>
-			
-		{% endif %}
+{% block post-body %}
 
-	    <h5 class="post-date"> {{ page.date }} </h5>
+    <div class="post-body">
+	    {{ page.body }}
+	    {{ page.paper_url }}
+	</div>
 
-	    <div class="post-body">
-		    {{ page.body }}
-		    {{ page.paper_url }}
+	<div class="post-attachment">
+		<div class="post-attachment__image"> </div>
+		<div class="post-attachment__text">
+			<h3>ATTACHMENT</h3>
+			{{ page.attachment }}
 		</div>
-
-		<div class="post-attachment">
-			<div class="post-attachment__image"> </div>
-			<div class="post-attachment__text">
-				<h3>ATTACHMENT</h3>
-				{{ page.attachment }}
-			</div>
-		</div>
-		
 	</div>
 
 {% endblock %}

--- a/press_release/templates/press_release/press_release.html
+++ b/press_release/templates/press_release/press_release.html
@@ -6,7 +6,7 @@
 {% block body_class %}template-pressrelease{% endblock %}
 
 
-{% block post-content %}
+{% block post-header %}
 	{% image page.story_image original as story_image %}
 
 	{% if story_image %}
@@ -35,33 +35,21 @@
 
 	{% endif %}
 
-	<div class="post-container">
+{% endblock %}
 
-	    {% if page.post_author.all %}
-		    	
-		    <h5 class="post-author">By 
-				{% for author in authors %}
-					<a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>
-				{% endfor %}
-			</h5>
-			
-		{% endif %}
+{% block post-body %}
 
-	    <h5 class="post-date"> {{ page.date }} </h5>
+    <div class="post-body">
+	    {{ page.body }}
+	    
+	</div>
 
-	    <div class="post-body">
-		    {{ page.body }}
-		    
+	<div class="post-attachment">
+		<div class="post-attachment__image"> </div>
+		<div class="post-attachment__text">
+			<h3>ATTACHMENT</h3>
+			{{ page.attachment }}
 		</div>
-
-		<div class="post-attachment">
-			<div class="post-attachment__image"> </div>
-			<div class="post-attachment__text">
-				<h3>ATTACHMENT</h3>
-				{{ page.attachment }}
-			</div>
-		</div>
-
 	</div>
 
 {% endblock %}

--- a/quoted/templates/quoted/quoted.html
+++ b/quoted/templates/quoted/quoted.html
@@ -5,7 +5,7 @@
 
 {% block body_class %}template-quoted{% endblock %}
 
-{% block post-content %}
+{% block post-header %}
 	{% image page.story_image original as story_image %}
 
 	{% if story_image %}
@@ -35,25 +35,14 @@
 
 	{% endif %}
 
-	<div class="post-container">
+{% endblock %}
 
-	    {% if page.post_author.all %}
-		    	
-		    <h5 class="post-author">In the News:  
-				{% for author in authors %}
-					<a href="{{ author.author.url }}">{{ author.author.first_name }} {{ author.author.last_name }}</a>
-				{% endfor %}
-			</h5>
-			
-		{% endif %}
+{% block post-body %}
 
-		<h5 class="post-source">Media Outlet: {{ page.source }} </h5>
-	    <h5 class="post-date"> {{ page.date }} </h5>
+	<h5 class="post-source">Media Outlet: {{ page.source }} </h5>
 
-	    <div class="post-body">
-		    {{ page.body }}
-		</div>
-
+    <div class="post-body">
+	    {{ page.body }}
 	</div>
 
 {% endblock %}

--- a/quoted/templates/quoted/quoted.html
+++ b/quoted/templates/quoted/quoted.html
@@ -37,6 +37,12 @@
 
 {% endblock %}
 
+{% block byline-prefix %}
+
+	In the News: 
+
+{% endblock %}
+
 {% block post-body %}
 
 	<h5 class="post-source">Media Outlet: {{ page.source }} </h5>


### PR DESCRIPTION
- incorporates logic for formatting of 1, 2 or 3+ authors in byline
- changes template inheritance to place author and date in post_page.html template, with post-header, byline-prefix, and post-body blocks left in individual post templates

Resolves #221 