### PR TITLE
Fixing Tests to Provide Required Fields

### DIFF
--- a/article/tests.py
+++ b/article/tests.py
@@ -10,104 +10,124 @@ from home.models import HomePage, PostProgramRelationship
 from programs.models import Program, Subprogram
 
 class ArticleTests(WagtailPageTests):
-	"""
-	Testing hierarchies between pages and whether it is possible 
-	to create an All Articles Homepage under the Homepage, 
-	a Program Articles Page under Program pages, Articles under 
-	Program Articles Pages. 
+    """
+    Testing hierarchies between pages and whether it is possible 
+    to create an All Articles Homepage under the Homepage, 
+    a Program Articles Page under Program pages, Articles under 
+    Program Articles Pages. 
 
-	Testing the many to many relationships between Programs and Articles. 
-	"""
-	
-	def setUp(self):
-		self.login()
-		self.root_page = Page.objects.get(id=1)
-		self.home_page = self.root_page.add_child(instance=HomePage(title='New America'))
-		self.program_page = self.home_page.add_child(instance=Program(title='OTI', name='OTI', location=False, depth=3))
-		self.program_articles_page = self.program_page.add_child(instance=ProgramArticlesPage(title='Program Articles'))
-		self.article = self.program_articles_page.add_child(instance=Article(title='Article 1', date='2016-02-02'))
-
-
-	#Test that a particular child Page type can be created under a parent Page type
-	def test_can_create_program_articles_page_under_program(self):
-		self.assertCanCreateAt(Program, ProgramArticlesPage)
-
-	def test_can_create_article_under_program_articles_page(self):
-		self.assertCanCreateAt(ProgramArticlesPage, Article)
-
-	def test_cant_create_article_under_all_articles_home_page(self):
-		self.assertCanNotCreateAt(AllArticlesHomePage, Article)
-
-
-	#Test that the only page types that child_model can be created under are parent_models
-	def test_article_parent_page(self):
-		self.assertAllowedParentPageTypes(Article, {ProgramArticlesPage})
-
-	def test_program_article_parent_page(self):
-		self.assertAllowedParentPageTypes(ProgramArticlesPage, {Program, Subprogram})
-
-	def test_all_articles_homepage_parent_page(self):
-		self.assertAllowedParentPageTypes(AllArticlesHomePage, {HomePage})
-
-
-	#Test that the only page types that can be created under parent_model are child_models
-	def test_article_subpages(self):
-		self.assertAllowedSubpageTypes(Article, {})
-
-	def test_program_article_subpages(self):
-		self.assertAllowedSubpageTypes(ProgramArticlesPage, {Article})
-
-	def test_all_articles_homepage_subpages(self):
-		self.assertAllowedSubpageTypes(AllArticlesHomePage, {})
+    Testing the many to many relationships between Programs and Articles. 
+    """
+    
+    def setUp(self):
+        self.login()
+        self.root_page = Page.objects.get(id=1)
+        self.home_page = self.root_page.add_child(instance=HomePage(
+            title='New America')
+        )
+        self.program_page = self.home_page.add_child(
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
+        )
+        self.program_articles_page = self.program_page.add_child(
+            instance=ProgramArticlesPage(title='Program Articles')
+        )
+        self.article = self.program_articles_page.add_child(instance=Article(title='Article 1', date='2016-02-02'))
 
 
-	#Test that pages can be created with POST data
-	def test_can_create_all_articles_homepage_under_homepage(self):
-		self.assertCanCreate(self.home_page, AllArticlesHomePage, {
-			'title':'Articles',
-			}
-		)
+    #Test that a particular child Page type can be created under a parent Page type
+    def test_can_create_program_articles_page_under_program(self):
+        self.assertCanCreateAt(Program, ProgramArticlesPage)
 
-	def test_can_create_program_articles_page(self):
-		self.assertCanCreate(self.program_page, ProgramArticlesPage, {
-			'title':'Articles',
-			}
-		)
+    def test_can_create_article_under_program_articles_page(self):
+        self.assertCanCreateAt(ProgramArticlesPage, Article)
+
+    def test_cant_create_article_under_all_articles_home_page(self):
+        self.assertCanNotCreateAt(AllArticlesHomePage, Article)
 
 
-	# Test relationship between article and one parent Program
-	def test_article_has_relationship_to_one_program(self):
-		article = Article.objects.all()[0]
-		self.assertEqual(article.parent_programs.all()[0].title, 'OTI')
+    #Test that the only page types that child_model can be created under are parent_models
+    def test_article_parent_page(self):
+        self.assertAllowedParentPageTypes(Article, {ProgramArticlesPage})
+
+    def test_program_article_parent_page(self):
+        self.assertAllowedParentPageTypes(ProgramArticlesPage, {Program, Subprogram})
+
+    def test_all_articles_homepage_parent_page(self):
+        self.assertAllowedParentPageTypes(AllArticlesHomePage, {HomePage})
 
 
-	# Test relationship between article and two parent Programs
-	def test_article_has_relationship_to_two_programs(self):
-		article = Article.objects.all()[0]
-		second_program = Program.objects.create(title='Education', name='Education', location=False, depth=3)
-		relationship, created = PostProgramRelationship.objects.get_or_create(program=second_program, post=article)
-		relationship.save()
-		self.assertEqual(article.parent_programs.all()[1].title, 'Education')
+    #Test that the only page types that can be created under parent_model are child_models
+    def test_article_subpages(self):
+        self.assertAllowedSubpageTypes(Article, {})
+
+    def test_program_article_subpages(self):
+        self.assertAllowedSubpageTypes(ProgramArticlesPage, {Article})
+
+    def test_all_articles_homepage_subpages(self):
+        self.assertAllowedSubpageTypes(AllArticlesHomePage, {})
 
 
-	# Test you can delete an article attached to one Program
-	def test_can_delete_blog_post_with_one_program(self):
-		article = Article.objects.first()
-		article.delete()
-		self.assertEqual(Article.objects.filter(title='Article 1').first(), None)
-		self.assertNotIn(article, ProgramArticlesPage.objects.filter(title='Program Articles').first().get_children())
-		self.assertEqual(PostProgramRelationship.objects.filter(post=article).first(), None)
-		self.assertEqual(PostProgramRelationship.objects.filter(post=article, program=self.program_page).first(), None)
+    #Test that pages can be created with POST data
+    def test_can_create_all_articles_homepage_under_homepage(self):
+        self.assertCanCreate(self.home_page, AllArticlesHomePage, {
+            'title':'Articles',
+            }
+        )
 
-	# Test article can be deleted if attached to two Programs
-	def test_can_delete_blog_post_with_two_programs(self):
-		article = Article.objects.first()
-		second_program = Program.objects.create(title='Education', name='Education', location=False, depth=3)
-		relationship, created = PostProgramRelationship.objects.get_or_create(program=second_program, post=article)
-		if created:
-			relationship.save()
-		article.delete()
-		self.assertEqual(Article.objects.filter(title='Article 1').first(), None)
-		self.assertNotIn(article, ProgramArticlesPage.objects.filter(title='Program Articles').first().get_children())
-		self.assertEqual(PostProgramRelationship.objects.filter(post=article, program=self.program_page).first(), None)
-		self.assertEqual(PostProgramRelationship.objects.filter(post=article, program=second_program).first(), None)
+    def test_can_create_program_articles_page(self):
+        self.assertCanCreate(self.program_page, ProgramArticlesPage, {
+            'title':'Articles',
+            }
+        )
+
+
+    # Test relationship between article and one parent Program
+    def test_article_has_relationship_to_one_program(self):
+        article = Article.objects.all()[0]
+        self.assertEqual(article.parent_programs.all()[0].title, 'OTI')
+
+
+    # Test relationship between article and two parent Programs
+    def test_article_has_relationship_to_two_programs(self):
+        article = Article.objects.all()[0]
+        relationship, created = PostProgramRelationship.objects.get_or_create(program=self.second_program, post=article)
+        relationship.save()
+        self.assertEqual(article.parent_programs.all()[1].title, 'Education')
+
+
+    # Test you can delete an article attached to one Program
+    def test_can_delete_blog_post_with_one_program(self):
+        article = Article.objects.first()
+        article.delete()
+        self.assertEqual(Article.objects.filter(title='Article 1').first(), None)
+        self.assertNotIn(article, ProgramArticlesPage.objects.filter(title='Program Articles').first().get_children())
+        self.assertEqual(PostProgramRelationship.objects.filter(post=article).first(), None)
+        self.assertEqual(PostProgramRelationship.objects.filter(post=article, program=self.program_page).first(), None)
+
+    # Test article can be deleted if attached to two Programs
+    def test_can_delete_blog_post_with_two_programs(self):
+        article = Article.objects.first()
+        relationship, created = PostProgramRelationship.objects.get_or_create(post=article, program=self.second_program)
+        if created:
+            relationship.save()
+        article.delete()
+        self.assertEqual(Article.objects.filter(title='Article 1').first(), None)
+        self.assertNotIn(article, ProgramArticlesPage.objects.filter(title='Program Articles').first().get_children())
+        self.assertEqual(PostProgramRelationship.objects.filter(post=article, program=self.program_page).first(), None)
+        self.assertEqual(PostProgramRelationship.objects.filter(post=article, program=self.second_program).first(), None)

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -10,104 +10,127 @@ from home.models import HomePage, PostProgramRelationship
 from programs.models import Program, Subprogram
 
 class BlogPostTests(WagtailPageTests):
-	"""
-	Testing the BlogPost, AllBlogPostsHomePage, and
-	ProgramBlogPostsPage models to confirm hierarchies
-	between pages and whether it is possible to create
-	pages where it is appropriate.
+    """
+    Testing the BlogPost, AllBlogPostsHomePage, and
+    ProgramBlogPostsPage models to confirm hierarchies
+    between pages and whether it is possible to create
+    pages where it is appropriate.
 
-	"""
+    """
 
-	def setUp(self):
-		self.login()
-		self.root_page = Page.objects.get(id=1)
-		self.home_page = self.root_page.add_child(instance=HomePage(title='New America'))
-		self.program_page_1 = self.home_page.add_child(instance=Program(title='OTI', name='OTI', location=False, depth=3))
-		self.program_blog_posts_page = self.program_page_1.add_child(instance=ProgramBlogPostsPage(title='OTI Blog'))
-		self.blog_post = self.program_blog_posts_page.add_child(instance=BlogPost(title='Blog Post 1', date='2016-02-10'))
-
-
-	# Test that a particular child Page can be created under 
-	# the appropriate parent Page 
-	def test_can_create_blog_post_under_program_blog_posts_page(self):
-		self.assertCanCreateAt(ProgramBlogPostsPage, BlogPost)
-
-	def test_cannot_create_blog_post_under_all_blog_posts_page(self):
-		self.assertCanNotCreateAt(AllBlogPostsHomePage, BlogPost)
-
-	def test_can_create_program_blog_posts_page_under_program(self):
-		self.assertCanCreateAt(Program, ProgramBlogPostsPage)
-
-
-	# Test allowed parent page types
-	def test_blog_post_parent_page(self):
-		self.assertAllowedParentPageTypes(BlogPost, {ProgramBlogPostsPage})
-
-	def test_program_blog_post_parent_page(self):
-		self.assertAllowedParentPageTypes(ProgramBlogPostsPage, {Program, Subprogram})
-
-	def test_all_blog_posts_parent_page(self):
-		self.assertAllowedParentPageTypes(AllBlogPostsHomePage, {HomePage})
-
-
-	# Test allowed subpage types
-	def test_blog_post_subpages(self):
-		self.assertAllowedSubpageTypes(BlogPost, {})
-
-	def test_program_blog_post_subpages(self):
-		self.assertAllowedSubpageTypes(ProgramBlogPostsPage, {BlogPost})
-	
-	def test_all_blog_post_subpages(self):
-		self.assertAllowedSubpageTypes(AllBlogPostsHomePage, {})
-
-	#Test that pages can be created with POST data
-	def test_can_create_all_blog_post_page_under_homepage(self):
-		self.assertCanCreate(self.home_page, AllBlogPostsHomePage, {
-			'title':'All Blogs Posts',
-			}
-		)
-
-	def test_can_create_program_blog_posts_page(self):
-		self.assertCanCreate(self.program_page_1, ProgramBlogPostsPage, {
-			'title':'Program Blogs',
-			}
-		)
+    def setUp(self):
+        self.login()
+        self.root_page = Page.objects.get(id=1)
+        self.home_page = self.root_page.add_child(instance=HomePage(
+            title='New America')
+        )
+        self.program_page_1 = self.home_page.add_child(
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
+        )       
+        self.program_blog_posts_page = self.program_page_1.add_child(instance=ProgramBlogPostsPage(title='OTI Blog'))
+        self.blog_post = self.program_blog_posts_page.add_child(
+            instance=BlogPost(
+                title='Blog Post 1', 
+                date='2016-02-10'
+            )
+        )
 
 
-	# Test relationship between BlogPost and one parent Program
-	def test_blog_post_has_relationship_to_one_program(self):
-		blog = BlogPost.objects.first()
-		self.assertEqual(blog.parent_programs.all()[0].title, 'OTI')
+    # Test that a particular child Page can be created under 
+    # the appropriate parent Page 
+    def test_can_create_blog_post_under_program_blog_posts_page(self):
+        self.assertCanCreateAt(ProgramBlogPostsPage, BlogPost)
+
+    def test_cannot_create_blog_post_under_all_blog_posts_page(self):
+        self.assertCanNotCreateAt(AllBlogPostsHomePage, BlogPost)
+
+    def test_can_create_program_blog_posts_page_under_program(self):
+        self.assertCanCreateAt(Program, ProgramBlogPostsPage)
 
 
-	# Test you can create a BlogPost with two parent Programs
-	def test_blog_post_has_relationship_to_two_parent_programs(self):
-		blog = BlogPost.objects.first()
-		second_program = Program.objects.create(title='Education', name='Education', location=False, depth=3)
-		relationship, created = PostProgramRelationship.objects.get_or_create(program=second_program, post=blog)
-		relationship.save()
-		self.assertEqual(blog.parent_programs.filter(title='Education').first().title, 'Education')
+    # Test allowed parent page types
+    def test_blog_post_parent_page(self):
+        self.assertAllowedParentPageTypes(BlogPost, {ProgramBlogPostsPage})
+
+    def test_program_blog_post_parent_page(self):
+        self.assertAllowedParentPageTypes(ProgramBlogPostsPage, {Program, Subprogram})
+
+    def test_all_blog_posts_parent_page(self):
+        self.assertAllowedParentPageTypes(AllBlogPostsHomePage, {HomePage})
 
 
-	# Test blog post can be deleted if BlogPost attached to one Program
-	def test_can_delete_blog_post_with_one_program(self):
-		blog = BlogPost.objects.first()
-		blog.delete()
-		self.assertEqual(BlogPost.objects.filter(title='Blog Post 1').first(), None)
-		self.assertNotIn(blog, ProgramBlogPostsPage.objects.filter(title='OTI Blog').first().get_children())
-		self.assertEqual(PostProgramRelationship.objects.filter(post=blog).first(), None)
-		self.assertEqual(PostProgramRelationship.objects.filter(post=blog, program=self.program_page_1).first(), None)
+    # Test allowed subpage types
+    def test_blog_post_subpages(self):
+        self.assertAllowedSubpageTypes(BlogPost, {})
+
+    def test_program_blog_post_subpages(self):
+        self.assertAllowedSubpageTypes(ProgramBlogPostsPage, {BlogPost})
+    
+    def test_all_blog_post_subpages(self):
+        self.assertAllowedSubpageTypes(AllBlogPostsHomePage, {})
+
+    #Test that pages can be created with POST data
+    def test_can_create_all_blog_post_page_under_homepage(self):
+        self.assertCanCreate(self.home_page, AllBlogPostsHomePage, {
+            'title':'All Blogs Posts',
+            }
+        )
+
+    def test_can_create_program_blog_posts_page(self):
+        self.assertCanCreate(self.program_page_1, ProgramBlogPostsPage, {
+            'title':'Program Blogs',
+            }
+        )
 
 
-	# Test blog post can be deleted if attached to two Programs
-	def test_can_delete_blog_post_with_two_programs(self):
-		blog = BlogPost.objects.first()
-		second_program = Program.objects.create(title='Education', name='Education', location=False, depth=3)
-		relationship, created = PostProgramRelationship.objects.get_or_create(program=second_program, post=blog)
-		if created:
-			relationship.save()
-		blog.delete()
-		self.assertEqual(BlogPost.objects.filter(title='Blog Post 1').first(), None)
-		self.assertNotIn(blog, ProgramBlogPostsPage.objects.filter(title='OTI Blog').first().get_children())
-		self.assertEqual(PostProgramRelationship.objects.filter(post=blog, program=self.program_page_1).first(), None)
-		self.assertEqual(PostProgramRelationship.objects.filter(post=blog, program=second_program).first(), None)
+    # Test relationship between BlogPost and one parent Program
+    def test_blog_post_has_relationship_to_one_program(self):
+        blog = BlogPost.objects.first()
+        self.assertEqual(blog.parent_programs.all()[0].title, 'OTI')
+
+
+    # Test you can create a BlogPost with two parent Programs
+    def test_blog_post_has_relationship_to_two_parent_programs(self):
+        blog = BlogPost.objects.first()
+        relationship, created = PostProgramRelationship.objects.get_or_create(program=self.second_program, post=blog)
+        relationship.save()
+        self.assertEqual(blog.parent_programs.filter(title='Education').first().title, 'Education')
+
+
+    # Test blog post can be deleted if BlogPost attached to one Program
+    def test_can_delete_blog_post_with_one_program(self):
+        blog = BlogPost.objects.first()
+        blog.delete()
+        self.assertEqual(BlogPost.objects.filter(title='Blog Post 1').first(), None)
+        self.assertNotIn(blog, ProgramBlogPostsPage.objects.filter(title='OTI Blog').first().get_children())
+        self.assertEqual(PostProgramRelationship.objects.filter(post=blog).first(), None)
+        self.assertEqual(PostProgramRelationship.objects.filter(post=blog, program=self.program_page_1).first(), None)
+
+
+    # Test blog post can be deleted if attached to two Programs
+    def test_can_delete_blog_post_with_two_programs(self):
+        blog = BlogPost.objects.first()
+        relationship, created = PostProgramRelationship.objects.get_or_create(program=self.second_program, post=blog)
+        if created:
+            relationship.save()
+        blog.delete()
+        self.assertEqual(BlogPost.objects.filter(title='Blog Post 1').first(), None)
+        self.assertNotIn(blog, ProgramBlogPostsPage.objects.filter(title='OTI Blog').first().get_children())
+        self.assertEqual(PostProgramRelationship.objects.filter(post=blog, program=self.program_page_1).first(), None)
+        self.assertEqual(PostProgramRelationship.objects.filter(post=blog, program=self.second_program).first(), None)

--- a/book/tests.py
+++ b/book/tests.py
@@ -12,105 +12,123 @@ from home.models import HomePage, PostProgramRelationship
 from programs.models import Program, Subprogram
 
 class BookTests(WagtailPageTests):
-	"""
-	Testing the Book, AllBooksHomePage, and
-	ProgramBooksPage models to confirm hierarchies
-	between pages and whether it is possible to create
-	pages where it is appropriate.
+    """
+    Testing the Book, AllBooksHomePage, and
+    ProgramBooksPage models to confirm hierarchies
+    between pages and whether it is possible to create
+    pages where it is appropriate.
 
-	"""
+    """
 
-	def setUp(self):
-		self.login()
-		self.root_page = Page.objects.get(id=1)
-		self.home_page = self.root_page.add_child(instance=HomePage(title='New America'))
-		self.program_page_1 = self.home_page.add_child(instance=Program(title='OTI', name='OTI', location=False, depth=3))
-		self.program_books_page = self.program_page_1.add_child(instance=ProgramBooksPage(title='OTI Books'))
-		self.book = self.program_books_page.add_child(instance=Book(title='Test Book 1', date='2016-02-10'))
-
-
-	# Test that a particular child Page can be created under 
-	# the appropriate parent Page 
-	def test_can_create_book_under_program_books_page(self):
-		self.assertCanCreateAt(ProgramBooksPage, Book)
-
-	def test_cannot_create_book_under_all_books_page(self):
-		self.assertCanNotCreateAt(AllBooksHomePage, Book)
-
-	def test_can_create_program_books_page_under_program(self):
-		self.assertCanCreateAt(Program, ProgramBooksPage)
-
-
-	# Test allowed parent page types
-	def test_book_parent_page(self):
-		self.assertAllowedParentPageTypes(Book, {ProgramBooksPage})
-
-	def test_program_book_parent_page(self):
-		self.assertAllowedParentPageTypes(ProgramBooksPage, {Program, Subprogram})
-
-	def test_all_books_parent_page(self):
-		self.assertAllowedParentPageTypes(AllBooksHomePage, {HomePage})
+    def setUp(self):
+        self.login()
+        self.root_page = Page.objects.get(id=1)
+        self.home_page = self.root_page.add_child(instance=HomePage(
+            title='New America')
+        )
+        self.program_page_1 = self.home_page.add_child(
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
+        )
+        self.program_books_page = self.program_page_1.add_child(instance=ProgramBooksPage(title='OTI Books'))
+        self.book = self.program_books_page.add_child(instance=Book(title='Test Book 1', date='2016-02-10'))
 
 
-	# Test allowed subpage types
-	def test_book_subpages(self):
-		self.assertAllowedSubpageTypes(Book, {})
+    # Test that a particular child Page can be created under 
+    # the appropriate parent Page 
+    def test_can_create_book_under_program_books_page(self):
+        self.assertCanCreateAt(ProgramBooksPage, Book)
 
-	def test_program_book_subpages(self):
-		self.assertAllowedSubpageTypes(ProgramBooksPage, {Book})
-	
-	def test_all_book_homepage_subpages(self):
-		self.assertAllowedSubpageTypes(AllBooksHomePage, {})
+    def test_cannot_create_book_under_all_books_page(self):
+        self.assertCanNotCreateAt(AllBooksHomePage, Book)
 
-	#Test that pages can be created with POST data
-	def test_can_create_all_book_page_under_homepage(self):
-		self.assertCanCreate(self.home_page, AllBooksHomePage, {
-			'title':'All Books at New America',
-			}
-		)
-
-	def test_can_create_program_books_page(self):
-		self.assertCanCreate(self.program_page_1, ProgramBooksPage, {
-			'title':'Program Blogs',
-			}
-		)
+    def test_can_create_program_books_page_under_program(self):
+        self.assertCanCreateAt(Program, ProgramBooksPage)
 
 
-	# Test relationship between Book and one parent Program
-	def test_book_has_relationship_to_one_program(self):
-		book = Book.objects.first()
-		self.assertEqual(book.parent_programs.all()[0].title, 'OTI')
+    # Test allowed parent page types
+    def test_book_parent_page(self):
+        self.assertAllowedParentPageTypes(Book, {ProgramBooksPage})
+
+    def test_program_book_parent_page(self):
+        self.assertAllowedParentPageTypes(ProgramBooksPage, {Program, Subprogram})
+
+    def test_all_books_parent_page(self):
+        self.assertAllowedParentPageTypes(AllBooksHomePage, {HomePage})
 
 
-	# Test you can create a Book with two parent Programs
-	def test_book_has_relationship_to_two_parent_programs(self):
-		book = Book.objects.first()
-		second_program = Program.objects.create(title='Education', name='Education', location=False, depth=3)
-		relationship, created = PostProgramRelationship.objects.get_or_create(program=second_program, post=book)
-		relationship.save()
-		self.assertEqual(book.parent_programs.filter(title='Education').first().title, 'Education')
+    # Test allowed subpage types
+    def test_book_subpages(self):
+        self.assertAllowedSubpageTypes(Book, {})
+
+    def test_program_book_subpages(self):
+        self.assertAllowedSubpageTypes(ProgramBooksPage, {Book})
+    
+    def test_all_book_homepage_subpages(self):
+        self.assertAllowedSubpageTypes(AllBooksHomePage, {})
+
+    #Test that pages can be created with POST data
+    def test_can_create_all_book_page_under_homepage(self):
+        self.assertCanCreate(self.home_page, AllBooksHomePage, {
+            'title':'All Books at New America',
+            }
+        )
+
+    def test_can_create_program_books_page(self):
+        self.assertCanCreate(self.program_page_1, ProgramBooksPage, {
+            'title':'Program Blogs',
+            }
+        )
 
 
-	# Test book can be deleted if attached to one Program
-	def test_can_delete_book_with_one_program(self):
-		book = Book.objects.first()
-		book.delete()
-		self.assertEqual(Book.objects.filter(title='Test Book 1').first(), None)
-		self.assertNotIn(book, ProgramBooksPage.objects.filter(title='OTI Books').first().get_children())
-		self.assertEqual(PostProgramRelationship.objects.filter(post=book).first(), None)
-		self.assertEqual(PostProgramRelationship.objects.filter(post=book, program=self.program_page_1).first(), None)
+    # Test relationship between Book and one parent Program
+    def test_book_has_relationship_to_one_program(self):
+        book = Book.objects.first()
+        self.assertEqual(book.parent_programs.all()[0].title, 'OTI')
 
 
-	# Test book can be deleted if attached to two Programs
-	def test_can_delete_book_with_two_programs(self):
-		book = Book.objects.first()
-		second_program = Program.objects.create(title='Education', name='Education', location=False, depth=3)
-		relationship, created = PostProgramRelationship.objects.get_or_create(program=second_program, post=book)
-		if created:
-			relationship.save()
-		book.delete()
-		self.assertEqual(Book.objects.filter(title='Test Book 1').first(), None)
-		self.assertNotIn(book, ProgramBooksPage.objects.filter(title='OTI Books').first().get_children())
-		self.assertEqual(PostProgramRelationship.objects.filter(post=book, program=self.program_page_1).first(), None)
-		self.assertEqual(PostProgramRelationship.objects.filter(post=book, program=second_program).first(), None)
+    # Test you can create a Book with two parent Programs
+    def test_book_has_relationship_to_two_parent_programs(self):
+        book = Book.objects.first()
+        relationship, created = PostProgramRelationship.objects.get_or_create(program=self.second_program, post=book)
+        relationship.save()
+        self.assertEqual(book.parent_programs.filter(title='Education').first().title, 'Education')
+
+
+    # Test book can be deleted if attached to one Program
+    def test_can_delete_book_with_one_program(self):
+        book = Book.objects.first()
+        book.delete()
+        self.assertEqual(Book.objects.filter(title='Test Book 1').first(), None)
+        self.assertNotIn(book, ProgramBooksPage.objects.filter(title='OTI Books').first().get_children())
+        self.assertEqual(PostProgramRelationship.objects.filter(post=book).first(), None)
+        self.assertEqual(PostProgramRelationship.objects.filter(post=book, program=self.program_page_1).first(), None)
+
+
+    # Test book can be deleted if attached to two Programs
+    def test_can_delete_book_with_two_programs(self):
+        book = Book.objects.first()
+        relationship, created = PostProgramRelationship.objects.get_or_create(program=self.second_program, post=book)
+        if created:
+            relationship.save()
+        book.delete()
+        self.assertEqual(Book.objects.filter(title='Test Book 1').first(), None)
+        self.assertNotIn(book, ProgramBooksPage.objects.filter(title='OTI Books').first().get_children())
+        self.assertEqual(PostProgramRelationship.objects.filter(post=book, program=self.program_page_1).first(), None)
+        self.assertEqual(PostProgramRelationship.objects.filter(post=book, program=self.second_program).first(), None)
 

--- a/event/tests.py
+++ b/event/tests.py
@@ -26,6 +26,9 @@ class EventTests(WagtailPageTests):
         self.home_page = self.root_page.add_child(instance=HomePage(
             title='New America')
         )
+        self.all_events_home_page = self.home_page.add_child(
+            instance=AllEventsHomePage(title="All Events at New America!")
+        )
         self.program_page_1 = self.home_page.add_child(
             instance=Program(
                 title='OTI',
@@ -52,11 +55,10 @@ class EventTests(WagtailPageTests):
             instance=Event(
                 title='Event 1',
                 date='2016-02-10',
-                
+                rsvp_link='http://www.newamerica.org',
+                soundcloud_url='http://www.newamerica.org'
+
             )
-        )
-        self.org_wide_event = self.all_events_home_page.add_child(
-            instance=Event(title="Org Event", date='2016-02-10')
         )
 
     # Test that a child Page can be created under
@@ -91,13 +93,13 @@ class EventTests(WagtailPageTests):
     # Test that pages can be created with POST data
     def test_can_create_all_event_page_under_homepage(self):
         self.assertCanCreate(self.home_page, AllEventsHomePage, {
-            'title': 'All Events at New America',
+            'title': 'All Events at New America2',
             }
         )
 
     def test_can_create_program_events_page(self):
         self.assertCanCreate(self.program_page_1, ProgramEventsPage, {
-            'title': 'Our Program Events',
+            'title': 'Our Program Events2',
             }
         )
 
@@ -107,10 +109,6 @@ class EventTests(WagtailPageTests):
         event = Event.objects.first()
         self.assertEqual(event.parent_programs.all()[0].title, 'OTI')
 
-    # Test relationship between event and all events homepage
-    def test_event_has_relationship_to_all_event_homepage(self):
-        event = Event.objects.filter(title="Org Event")
-        self.assertTrue(event.child_of(self.all_events_home_page))
 
     # Test you can create a event with two parent Programs
     def test_event_has_relationship_to_two_parent_programs(self):

--- a/event/tests.py
+++ b/event/tests.py
@@ -26,17 +26,34 @@ class EventTests(WagtailPageTests):
         self.home_page = self.root_page.add_child(instance=HomePage(
             title='New America')
         )
-        self.all_events_home_page = self.home_page.add_child(
-            instance=AllEventsHomePage(title="All Events at New America!")
-        )
         self.program_page_1 = self.home_page.add_child(
-            instance=Program(title='OTI', name='OTI', location=False, depth=3)
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
         )
         self.program_events_page = self.program_page_1.add_child(
             instance=ProgramEventsPage(title='OTI Events')
         )
         self.event = self.program_events_page.add_child(
-            instance=Event(title='Event 1', date='2016-02-10')
+            instance=Event(
+                title='Event 1',
+                date='2016-02-10',
+                
+            )
         )
         self.org_wide_event = self.all_events_home_page.add_child(
             instance=Event(title="Org Event", date='2016-02-10')
@@ -98,10 +115,8 @@ class EventTests(WagtailPageTests):
     # Test you can create a event with two parent Programs
     def test_event_has_relationship_to_two_parent_programs(self):
         event = Event.objects.first()
-        second_program = Program.objects.create(
-            title='Education', name='Education', location=False, depth=3)
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=second_program, post=event)
+            program=self.second_program, post=event)
         relationship.save()
         self.assertEqual(
             event.parent_programs.filter(title='Education').first().title,
@@ -123,10 +138,8 @@ class EventTests(WagtailPageTests):
     # Test event can be deleted if attached to two Programs
     def test_can_delete_event_with_two_programs(self):
         event = Event.objects.filter(title='Event 1').first()
-        second_program = Program.objects.create(
-            title='Education', name='Education', location=False, depth=3)
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=second_program, post=event)
+            program=self.second_program, post=event)
         if created:
             relationship.save()
         event.delete()
@@ -136,4 +149,4 @@ class EventTests(WagtailPageTests):
         self.assertEqual(PostProgramRelationship.objects.filter(
             post=event, program=self.program_page_1).first(), None)
         self.assertEqual(PostProgramRelationship.objects.filter(
-            post=event, program=second_program).first(), None)
+            post=event, program=self.second_program).first(), None)

--- a/podcast/tests.py
+++ b/podcast/tests.py
@@ -27,7 +27,23 @@ class PodcastTests(WagtailPageTests):
             instance=AllPodcastsHomePage(title="All Podcasts at New America!")
         )
         self.program_page_1 = self.home_page.add_child(
-            instance=Program(title='OTI', name='OTI', location=False, depth=3)
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
         )
         self.program_podcasts_page = self.program_page_1.add_child(
             instance=ProgramPodcastsPage(
@@ -67,7 +83,7 @@ class PodcastTests(WagtailPageTests):
     # Test that pages can be created with POST data
     def test_can_create_all_podcasts_page_under_homepage(self):
         self.assertCanCreate(self.home_page, AllPodcastsHomePage, {
-            'title': 'All Podcasts at New America',
+            'title': 'All Podcasts at New America2',
             }
         )
 
@@ -86,10 +102,8 @@ class PodcastTests(WagtailPageTests):
     # Test you can create a podcast with two parent Programs
     def test_podcast_has_relationship_to_two_parent_programs(self):
         podcast = Podcast.objects.first()
-        second_program = Program.objects.create(
-            title='Education', name='Education', location=False, depth=3)
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=second_program, post=podcast)
+            program=self.second_program, post=podcast)
         relationship.save()
         self.assertEqual(
             podcast.parent_programs.filter(title='Education').first().title,
@@ -123,14 +137,8 @@ class PodcastTests(WagtailPageTests):
     def test_podcast_with_two_parent_programs_can_be_deleted(self):
         podcast = Podcast.objects.filter(
             title='Podcast 1').first()
-        program_page_2 = Program.objects.create(
-            title='Education',
-            name='Education',
-            location='False',
-            depth=3
-        )
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=program_page_2,
+            program=self.second_program,
             post=podcast
             )
         if created:
@@ -153,5 +161,5 @@ class PodcastTests(WagtailPageTests):
         self.assertEqual(
             PostProgramRelationship.objects.filter(
                 post=podcast,
-                program=program_page_2).first(), None
+                program=self.second_program).first(), None
         )

--- a/policy_paper/tests.py
+++ b/policy_paper/tests.py
@@ -27,7 +27,23 @@ class PolicyPaperTests(WagtailPageTests):
             instance=AllPolicyPapersHomePage(title='New America Policy Papers')
         )
         self.program_page_1 = self.home_page.add_child(
-            instance=Program(title='OTI', name='OTI', location=False, depth=3)
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
         )
         self.program_policy_papers_page = self.program_page_1\
             .add_child(instance=ProgramPolicyPapersPage(
@@ -82,7 +98,7 @@ class PolicyPaperTests(WagtailPageTests):
     # Test that pages can be created with POST data
     def test_can_create_all_policy_papers_page_under_homepage(self):
         self.assertCanCreate(self.home_page, AllPolicyPapersHomePage, {
-            'title': 'New America Policy Papers',
+            'title': 'New America Policy Papers2',
             }
         )
 
@@ -100,10 +116,8 @@ class PolicyPaperTests(WagtailPageTests):
     # Test you can create a policy paper with two parent Programs
     def test_policy_paper_has_relationship_to_two_parent_programs(self):
         policy_paper = PolicyPaper.objects.first()
-        second_program = Program.objects.create(
-            title='Education', name='Education', location=False, depth=3)
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=second_program, post=policy_paper)
+            program=self.second_program, post=policy_paper)
         relationship.save()
         self.assertEqual(
             policy_paper.parent_programs.filter(
@@ -138,14 +152,8 @@ class PolicyPaperTests(WagtailPageTests):
     def test_policy_paper_with_two_parent_programs_can_be_deleted(self):
         policy_paper = PolicyPaper.objects.filter(
             title='Policy Paper 1').first()
-        program_page_2 = Program.objects.create(
-            title='Education',
-            name='Education',
-            location='False',
-            depth=3
-        )
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=program_page_2,
+            program=self.second_program,
             post=policy_paper
             )
         if created:
@@ -168,5 +176,5 @@ class PolicyPaperTests(WagtailPageTests):
         self.assertEqual(
             PostProgramRelationship.objects.filter(
                 post=policy_paper,
-                program=program_page_2).first(), None
+                program=self.second_program).first(), None
         )

--- a/press_release/tests.py
+++ b/press_release/tests.py
@@ -30,7 +30,23 @@ class PressReleaseTests(WagtailPageTests):
             )
         )
         self.program_page_1 = self.home_page.add_child(
-            instance=Program(title='OTI', name='OTI', location=False, depth=3)
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
         )
         self.program_press_releases_page = self.program_page_1\
             .add_child(instance=ProgramPressReleasesPage(
@@ -88,7 +104,7 @@ class PressReleaseTests(WagtailPageTests):
     # Test that pages can be created with POST data
     def test_can_create_all_press_releases_page_under_homepage(self):
         self.assertCanCreate(self.home_page, AllPressReleasesHomePage, {
-            'title': 'New America Press Releases',
+            'title': 'New America Press Releases2',
             }
         )
 
@@ -106,10 +122,8 @@ class PressReleaseTests(WagtailPageTests):
     # Test you can create a press release with two parent Programs
     def test_press_release_has_relationship_to_two_parent_programs(self):
         press_release = PressRelease.objects.first()
-        second_program = Program.objects.create(
-            title='Education', name='Education', location=False, depth=3)
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=second_program, post=press_release)
+            program=self.second_program, post=press_release)
         relationship.save()
         self.assertEqual(
             press_release.parent_programs.filter(
@@ -144,14 +158,8 @@ class PressReleaseTests(WagtailPageTests):
     def test_press_release_with_two_parent_programs_can_be_deleted(self):
         press_release = PressRelease.objects.filter(
             title='Press Release 1').first()
-        program_page_2 = Program.objects.create(
-            title='Education',
-            name='Education',
-            location='False',
-            depth=3
-        )
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=program_page_2,
+            program=self.second_program,
             post=press_release
             )
         if created:
@@ -174,5 +182,5 @@ class PressReleaseTests(WagtailPageTests):
         self.assertEqual(
             PostProgramRelationship.objects.filter(
                 post=press_release,
-                program=program_page_2).first(), None
+                program=self.second_program).first(), None
         )

--- a/quoted/tests.py
+++ b/quoted/tests.py
@@ -27,7 +27,23 @@ class QuotedTests(WagtailPageTests):
             instance=AllQuotedHomePage(title='New America In The News')
         )
         self.program_page_1 = self.home_page.add_child(
-            instance=Program(title='OTI', name='OTI', description='OTI',location=False, depth=3)
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.second_program = self.home_page.add_child(
+            instance=Program(
+            title='Education', 
+            name='Education', 
+            slug='education', 
+            description='Education', 
+            location=False, 
+            depth=3
+            )
         )
         self.program_quoted_page = self.program_page_1\
             .add_child(instance=ProgramQuotedPage(
@@ -101,17 +117,8 @@ class QuotedTests(WagtailPageTests):
     # Test you can create a quoted item with two parent Programs
     def test_quoted_has_relationship_to_two_parent_programs(self):
         quoted = Quoted.objects.first()
-        second_program = Program(
-            title='Education', 
-            name='Education', 
-            slug='education', 
-            description='Education', 
-            location=False, 
-            depth=3
-        )
-        self.home_page.add_child(instance=second_program)
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=second_program, post=quoted)
+            program=self.second_program, post=quoted)
         relationship.save()
         self.assertEqual(
             quoted.parent_programs.filter(
@@ -146,17 +153,8 @@ class QuotedTests(WagtailPageTests):
     def test_quoted_with_two_parent_programs_can_be_deleted(self):
         quoted = Quoted.objects.filter(
             title='Quoted 1').first()
-        second_program = Program(
-            title='Education', 
-            name='Education', 
-            slug='education', 
-            description='Education', 
-            location=False, 
-            depth=3
-        )
-        self.home_page.add_child(instance=second_program)
         relationship, created = PostProgramRelationship.objects.get_or_create(
-            program=second_program,
+            program=self.second_program,
             post=quoted
             )
         if created:
@@ -179,6 +177,6 @@ class QuotedTests(WagtailPageTests):
         self.assertEqual(
             PostProgramRelationship.objects.filter(
                 post=quoted,
-                program=second_program).first(), None
+                program=self.second_program).first(), None
         )
 


### PR DESCRIPTION
- Django upgrade is enforcing (thankfully) required fields to have default values. Updating the tests to provide these required fields. 