### PR TITLE
Tests for the Program and Subprogram models

### DIFF
--- a/issue/models.py
+++ b/issue/models.py
@@ -12,7 +12,7 @@ from programs.models import Program
 
 
 class IssueOrTopic(ProgramSimplePage):
-    parent_page_types = ['programs.Program', 'IssueOrTopic']
+    parent_page_types = ['programs.Program', 'IssueOrTopic', 'programs.Subprogram']
     subpage_types = ['IssueOrTopic']
 
     def get_context(self, request):

--- a/issue/tests.py
+++ b/issue/tests.py
@@ -5,7 +5,7 @@ from .models import IssueOrTopic
 
 from home.models import HomePage, PostProgramRelationship
 
-from programs.models import Program
+from programs.models import Program, Subprogram
 
 
 class IssueOrTopicTests(WagtailPageTests):
@@ -35,7 +35,7 @@ class IssueOrTopicTests(WagtailPageTests):
     # Test allowed parent page types
     def test_issue_parent_page(self):
         self.assertAllowedParentPageTypes(
-            IssueOrTopic, {Program, IssueOrTopic}
+            IssueOrTopic, {Program, IssueOrTopic, Subprogram}
         )
 
     # Test allowed subpage types

--- a/programs/models.py
+++ b/programs/models.py
@@ -173,6 +173,20 @@ class AbstractProgram(Page):
 # Programs model which creates programs
 class Program(AbstractProgram):
     parent_page_types = ['home.HomePage']
+    subpage_types = [
+    'article.ProgramArticlesPage',
+    'book.ProgramBooksPage',
+    'blog.ProgramBlogPostsPage',
+    'event.ProgramEventsPage',
+    'podcast.ProgramPodcastsPage',
+    'policy_paper.ProgramPolicyPapersPage',
+    'press_release.ProgramPressReleasesPage',
+    'quoted.ProgramQuotedPage',
+    'home.ProgramSimplePage',
+    'person.ProgramPeoplePage',
+    'Subprogram',
+    'issue.IssueOrTopic',
+    ]
 
     program_logo = models.ForeignKey(
         'wagtailimages.Image',
@@ -225,6 +239,20 @@ class ProgramSubprogramRelationship(models.Model):
 # Subprograms models which when instantiated can be linked to multiple programs
 class Subprogram(AbstractProgram):
     parent_page_types = ['programs.Program']
+    subpage_types = [
+    'article.ProgramArticlesPage',
+    'book.ProgramBooksPage',
+    'blog.ProgramBlogPostsPage',
+    'event.ProgramEventsPage',
+    'podcast.ProgramPodcastsPage',
+    'policy_paper.ProgramPolicyPapersPage',
+    'press_release.ProgramPressReleasesPage',
+    'quoted.ProgramQuotedPage',
+    'home.ProgramSimplePage',
+    'person.ProgramPeoplePage',
+    'issue.IssueOrTopic',
+    ]
+
     parent_programs = models.ManyToManyField(
         Program,
         through=ProgramSubprogramRelationship,

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -182,5 +182,39 @@ class ProgramsTests(WagtailPageTests):
             self.article.id
         )
 
+    # Test adding pages to the Program sidebar menu 
+    def test_adding_about_us_pages_to_program_sidebar_menu(self):
+        self.program_page.sidebar_menu_about_us_pages.stream_data.append(
+            {
+                'type': 'Item',
+                'value': self.article.id
+            }
+        )
+        self.assertEqual(
+            self.program_page.sidebar_menu_about_us_pages.stream_data[0]['value'], 
+            self.article.id
+        )
 
-    
+    def test_adding_initiatives_and_projects_pages_to_program_sidebar_menu(self):
+        self.program_page.sidebar_menu_initiatives_and_projects_pages.stream_data.append(
+            {
+                'type': 'Item',
+                'value': self.article.id
+            }
+        )
+        self.assertEqual(
+            self.program_page.sidebar_menu_initiatives_and_projects_pages.stream_data[0]['value'], 
+            self.article.id
+        )
+
+    def test_adding_our_work_pages_to_program_sidebar_menu(self):
+        self.program_page.sidebar_menu_our_work_pages.stream_data.append(
+            {
+                'type': 'Item',
+                'value': self.article.id
+            }
+        )
+        self.assertEqual(
+            self.program_page.sidebar_menu_our_work_pages.stream_data[0]['value'], 
+            self.article.id
+        )

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -9,21 +9,23 @@ from weekly.models import Weekly
 
 from article.models import AllArticlesHomePage, ProgramArticlesPage, Article
 
-from event.models import AllEventsHomePage
+from event.models import AllEventsHomePage, ProgramEventsPage
 
-from blog.models import AllBlogPostsHomePage
+from blog.models import AllBlogPostsHomePage, ProgramBlogPostsPage
 
-from book.models import AllBooksHomePage
+from book.models import AllBooksHomePage, ProgramBooksPage
 
-from person.models import OurPeoplePage, BoardAndLeadershipPeoplePage
+from person.models import OurPeoplePage, BoardAndLeadershipPeoplePage, ProgramPeoplePage
 
-from podcast.models import AllPodcastsHomePage
+from podcast.models import AllPodcastsHomePage, ProgramPodcastsPage
 
-from policy_paper.models import AllPolicyPapersHomePage
+from policy_paper.models import AllPolicyPapersHomePage, ProgramPolicyPapersPage
 
-from press_release.models import AllPressReleasesHomePage
+from press_release.models import AllPressReleasesHomePage, ProgramPressReleasesPage
 
-from quoted.models import AllQuotedHomePage
+from quoted.models import AllQuotedHomePage, ProgramQuotedPage
+
+from issue.models import IssueOrTopic
 
 
 class ProgramsTests(WagtailPageTests):
@@ -60,53 +62,65 @@ class ProgramsTests(WagtailPageTests):
             )
         )
 
-    def test_can_create_homepage_under_root_page(self):
-        parent_page = Page.get_first_root_node()
-        home = HomePage(title='New America')
-        parent_page.add_child(instance=home)
-
     # Test that a particular child Page type 
     # can be created under a parent Page type
-    def test_homepage_parent_page_type(self):
-        self.assertCanCreateAt(Page, HomePage)
+    def test_program_parent_page_type(self):
+        self.assertCanCreateAt(HomePage, Program)
+
+    def test_subprogram_parent_page_type(self):
+        self.assertCanCreateAt(Program, Subprogram)
+
+    def test_subprogram_not_parent_page(self):
+        self.assertCanNotCreateAt(HomePage, Subprogram)
 
     # Test that the only page types that can be created 
     # under parent_model are child_models
-    def test_homepage_subpages(self):
-        self.assertAllowedSubpageTypes(HomePage, {
-            AllArticlesHomePage,
-            AllBooksHomePage,
-            AllBlogPostsHomePage,
-            AllEventsHomePage,
-            AllPodcastsHomePage,
-            AllPolicyPapersHomePage,
-            AllPressReleasesHomePage,
-            AllQuotedHomePage,
-            BoardAndLeadershipPeoplePage,
-            JobsPage,
-            OurPeoplePage, 
-            OrgSimplePage,
-            Program,
-            SubscribePage,
-            Weekly,
-            })
-
-    # Test that pages can be created with POST data
-    def test_can_create_homepage_under_page(self):
-        self.assertCanCreate(self.root_page, HomePage, {
-            'title': 'New America 2',
-            'slug': 'new-america-2',
-            'recent_carousel-count': 0,
+    def test_program_subpages(self):
+        self.assertAllowedSubpageTypes(
+            Program, 
+            {
+                ProgramArticlesPage,
+                ProgramBooksPage,
+                ProgramBlogPostsPage,
+                ProgramEventsPage,
+                ProgramPodcastsPage,
+                ProgramPolicyPapersPage,
+                ProgramPressReleasesPage,
+                ProgramQuotedPage,
+                ProgramSimplePage,
+                ProgramPeoplePage,
+                Subprogram,
+                IssueOrTopic,
             }
         )
 
-    def test_can_create_program_under_homepage_with_data(self):
+    def test_subprogram_subpages(self):
+        self.assertAllowedSubpageTypes(
+            Subprogram, 
+            {
+                ProgramArticlesPage,
+                ProgramBooksPage,
+                ProgramBlogPostsPage,
+                ProgramEventsPage,
+                ProgramPodcastsPage,
+                ProgramPolicyPapersPage,
+                ProgramPressReleasesPage,
+                ProgramQuotedPage,
+                ProgramSimplePage,
+                ProgramPeoplePage,
+                IssueOrTopic,
+            }
+        )
+
+    # Test that pages can be created with POST data
+    def test_can_create_program_under_homepage(self):
         self.assertCanCreate(self.home_page, Program, {
-            'title': 'OTI2',
-            'name': 'OTI2',
-            'description': 'OTI2',
-            'slug': 'oti-2',
+            'title': 'Test Program 1',
+            'name': 'Test Program 1',
+            'slug': 'test-program-1',
+            'description': 'Test description',
             'depth': 3,
+            'location': False,
             'feature_carousel-count': 0,
             'sidebar_menu_initiatives_and_projects_pages-count': 0,
             'sidebar_menu_our_work_pages-count': 0,
@@ -114,54 +128,4 @@ class ProgramsTests(WagtailPageTests):
             }
         )
 
-    def test_adding_lead_story_to_homepage(self):
-        self.home_page.lead_1 = self.article
-        self.home_page.save()
-        self.assertEqual(self.home_page.lead_1, self.article)
-
-    def test_adding_feature_story_to_homepage(self):
-        self.home_page.feature_1 = self.article
-        self.home_page.save()
-        self.assertEqual(self.home_page.feature_1, self.article)
-
-    def test_adding_story_to_homepage_recent_carousel(self):
-        self.home_page.recent_carousel.stream_data.append(
-            {
-                'type': 'event',
-                'value': self.article.id
-            }
-        )
-        self.assertEqual(
-            self.home_page.recent_carousel.stream_data[0]['value'], 
-            self.article.id
-        )
-
-    def test_adding_org_simple_page(self):
-        simple_page = OrgSimplePage(
-            title='Org Simple Page Test'
-        )
-        self.home_page.add_child(instance=simple_page)
-        self.assertEqual(simple_page.content_type, 
-            self.home_page.get_children().filter(
-            title='Org Simple Page Test')[0].content_type
-        )
-
-    def test_adding_excerpt_to_simple_page(self):
-        excerpt = 'This is a cool excerpt!'
-        simple_page = OrgSimplePage(
-            title='Org Simple Page Test',
-            story_excerpt=excerpt
-        )
-        self.home_page.add_child(instance=simple_page)
-        self.assertEqual(excerpt, OrgSimplePage.objects.first().story_excerpt)
-
-
-    def test_adding_program_simple_page(self):
-        program_simple_page = ProgramSimplePage(
-            title='Program Simple Page Test'
-        )
-        self.program_page.add_child(instance=program_simple_page)
-        self.assertEqual(program_simple_page.content_type, 
-            self.program_page.get_children().filter(
-            title='Program Simple Page Test')[0].content_type
-        )
+    

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -1,3 +1,167 @@
-from django.test import TestCase
+from wagtail.tests.utils import WagtailPageTests
+from wagtail.wagtailcore.models import Page
 
-# Create your tests here.
+from home.models import HomePage, OrgSimplePage, ProgramSimplePage, JobsPage, SubscribePage
+
+from .models import Program, Subprogram, ProgramSubprogramRelationship
+
+from weekly.models import Weekly
+
+from article.models import AllArticlesHomePage, ProgramArticlesPage, Article
+
+from event.models import AllEventsHomePage
+
+from blog.models import AllBlogPostsHomePage
+
+from book.models import AllBooksHomePage
+
+from person.models import OurPeoplePage, BoardAndLeadershipPeoplePage
+
+from podcast.models import AllPodcastsHomePage
+
+from policy_paper.models import AllPolicyPapersHomePage
+
+from press_release.models import AllPressReleasesHomePage
+
+from quoted.models import AllQuotedHomePage
+
+
+class ProgramsTests(WagtailPageTests):
+    """
+    Testing hierarchies between pages and whether it is possible 
+    to create a Homepage and all the allowed subpages 
+    underneath the Homepage.
+
+    Testing functionality of OrgSimplePage and ProgramSimplePage.
+    """
+
+    def setUp(self):
+        self.login()
+        self.root_page = Page.objects.get(id=1)
+        self.home_page = self.root_page.add_child(instance=HomePage(
+            title='New America')
+        )
+        self.program_page = self.home_page.add_child(
+            instance=Program(
+                title='OTI',
+                name='OTI',
+                description='OTI',
+                location=False,
+                depth=3
+            )
+        )
+        self.program_articles_page = self.program_page.add_child(
+            instance=ProgramArticlesPage(title='Program Articles')
+        )
+        self.article = self.program_articles_page.add_child(
+            instance=Article(
+                title='Article 1', 
+                date='2016-02-02'
+            )
+        )
+
+    def test_can_create_homepage_under_root_page(self):
+        parent_page = Page.get_first_root_node()
+        home = HomePage(title='New America')
+        parent_page.add_child(instance=home)
+
+    # Test that a particular child Page type 
+    # can be created under a parent Page type
+    def test_homepage_parent_page_type(self):
+        self.assertCanCreateAt(Page, HomePage)
+
+    # Test that the only page types that can be created 
+    # under parent_model are child_models
+    def test_homepage_subpages(self):
+        self.assertAllowedSubpageTypes(HomePage, {
+            AllArticlesHomePage,
+            AllBooksHomePage,
+            AllBlogPostsHomePage,
+            AllEventsHomePage,
+            AllPodcastsHomePage,
+            AllPolicyPapersHomePage,
+            AllPressReleasesHomePage,
+            AllQuotedHomePage,
+            BoardAndLeadershipPeoplePage,
+            JobsPage,
+            OurPeoplePage, 
+            OrgSimplePage,
+            Program,
+            SubscribePage,
+            Weekly,
+            })
+
+    # Test that pages can be created with POST data
+    def test_can_create_homepage_under_page(self):
+        self.assertCanCreate(self.root_page, HomePage, {
+            'title': 'New America 2',
+            'slug': 'new-america-2',
+            'recent_carousel-count': 0,
+            }
+        )
+
+    def test_can_create_program_under_homepage_with_data(self):
+        self.assertCanCreate(self.home_page, Program, {
+            'title': 'OTI2',
+            'name': 'OTI2',
+            'description': 'OTI2',
+            'slug': 'oti-2',
+            'depth': 3,
+            'feature_carousel-count': 0,
+            'sidebar_menu_initiatives_and_projects_pages-count': 0,
+            'sidebar_menu_our_work_pages-count': 0,
+            'sidebar_menu_about_us_pages-count': 0,
+            }
+        )
+
+    def test_adding_lead_story_to_homepage(self):
+        self.home_page.lead_1 = self.article
+        self.home_page.save()
+        self.assertEqual(self.home_page.lead_1, self.article)
+
+    def test_adding_feature_story_to_homepage(self):
+        self.home_page.feature_1 = self.article
+        self.home_page.save()
+        self.assertEqual(self.home_page.feature_1, self.article)
+
+    def test_adding_story_to_homepage_recent_carousel(self):
+        self.home_page.recent_carousel.stream_data.append(
+            {
+                'type': 'event',
+                'value': self.article.id
+            }
+        )
+        self.assertEqual(
+            self.home_page.recent_carousel.stream_data[0]['value'], 
+            self.article.id
+        )
+
+    def test_adding_org_simple_page(self):
+        simple_page = OrgSimplePage(
+            title='Org Simple Page Test'
+        )
+        self.home_page.add_child(instance=simple_page)
+        self.assertEqual(simple_page.content_type, 
+            self.home_page.get_children().filter(
+            title='Org Simple Page Test')[0].content_type
+        )
+
+    def test_adding_excerpt_to_simple_page(self):
+        excerpt = 'This is a cool excerpt!'
+        simple_page = OrgSimplePage(
+            title='Org Simple Page Test',
+            story_excerpt=excerpt
+        )
+        self.home_page.add_child(instance=simple_page)
+        self.assertEqual(excerpt, OrgSimplePage.objects.first().story_excerpt)
+
+
+    def test_adding_program_simple_page(self):
+        program_simple_page = ProgramSimplePage(
+            title='Program Simple Page Test'
+        )
+        self.program_page.add_child(instance=program_simple_page)
+        self.assertEqual(program_simple_page.content_type, 
+            self.program_page.get_children().filter(
+            title='Program Simple Page Test')[0].content_type
+        )

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -31,10 +31,13 @@ from issue.models import IssueOrTopic
 class ProgramsTests(WagtailPageTests):
     """
     Testing hierarchies between pages and whether it is possible 
-    to create a Homepage and all the allowed subpages 
-    underneath the Homepage.
+    to create a Program and all the allowed subpages 
+    underneath Programs and Subprograms.
 
-    Testing functionality of OrgSimplePage and ProgramSimplePage.
+    Testing functionality of lead, feature, and feature carousels on 
+    the landing page.
+
+    Also testing for Programs adding items the sidebar menu.
     """
 
     def setUp(self):

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -52,6 +52,15 @@ class ProgramsTests(WagtailPageTests):
                 depth=3
             )
         )
+        self.subprogram_page = self.program_page.add_child(
+            instance=Subprogram(
+                title='OTI Subprogram',
+                name='OTI Subprogram',
+                description='OTI Subprogram',
+                location=False,
+                depth=4,
+            )
+        )
         self.program_articles_page = self.program_page.add_child(
             instance=ProgramArticlesPage(title='Program Articles')
         )
@@ -127,5 +136,51 @@ class ProgramsTests(WagtailPageTests):
             'sidebar_menu_about_us_pages-count': 0,
             }
         )
+
+    # Test adding lead and feature stories to program and subprogram pages
+    def test_adding_lead_story_to_program(self):
+        self.program_page.lead_1 = self.article
+        self.program_page.save()
+        self.assertEqual(self.program_page.lead_1, self.article)
+
+    def test_adding_lead_story_to_subprogram(self):
+        self.subprogram_page.lead_1 = self.article
+        self.subprogram_page.save()
+        self.assertEqual(self.subprogram_page.lead_1, self.article)
+
+    def test_adding_feature_story_to_program(self):
+        self.program_page.feature_1 = self.article
+        self.program_page.save()
+        self.assertEqual(self.program_page.feature_1, self.article)
+
+    def test_adding_feature_story_to_subprogram(self):
+        self.subprogram_page.feature_1 = self.article
+        self.subprogram_page.save()
+        self.assertEqual(self.subprogram_page.feature_1, self.article)
+
+    def test_adding_story_to_program_feature_carousel(self):
+        self.program_page.feature_carousel.stream_data.append(
+            {
+                'type': 'event',
+                'value': self.article.id
+            }
+        )
+        self.assertEqual(
+            self.program_page.feature_carousel.stream_data[0]['value'], 
+            self.article.id
+        )
+
+    def test_adding_story_to_subprogram_feature_carousel(self):
+        self.subprogram_page.feature_carousel.stream_data.append(
+            {
+                'type': 'event',
+                'value': self.article.id
+            }
+        )
+        self.assertEqual(
+            self.subprogram_page.feature_carousel.stream_data[0]['value'], 
+            self.article.id
+        )
+
 
     


### PR DESCRIPTION
- Testing allowed parent and subpage types for Programs and Subprograms
- Testing features such as lead and feature stories and feature carousel stories for landing pages
- Testing the sidebar menu for Programs
- Updating parent page types for Issue model to reflect new ability of Subprograms to be able to add Issue/Topic pages
- Updating Issue tests to reflect new parent page type of Subprogram

[Resolves #6]