### PR TITLE
Feature to filter content by program, initiative, or date on content homepages

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -5,7 +5,7 @@ from home.models import Post
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 
 class Article(Post):
@@ -38,13 +38,13 @@ class AllArticlesHomePage(Page):
     subpage_types = []
 
     def get_context(self, request):
-        context = super(AllArticlesHomePage, self).get_context(request)
 
-        all_posts = Article.objects.all().order_by("-date")
-
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllArticlesHomePage,
+            Article
+        )
 
     class Meta:
         verbose_name = "Homepage for all Articles and Op-Eds"

--- a/blog/models.py
+++ b/blog/models.py
@@ -9,7 +9,7 @@ from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 
 class BlogPost(Post):
@@ -39,13 +39,12 @@ class AllBlogPostsHomePage(Page):
     subpage_types = []
 
     def get_context(self, request):
-        context = super(AllBlogPostsHomePage, self).get_context(request)
-        
-        all_posts = BlogPost.objects.all().order_by("-date")
-
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllBlogPostsHomePage,
+            BlogPost
+        )
 
     class Meta:
         verbose_name = "Homepage for all Blog Posts"

--- a/book/models.py
+++ b/book/models.py
@@ -5,7 +5,7 @@ from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
 from home.models import Post
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 
 class Book(Post):
@@ -38,12 +38,12 @@ class AllBooksHomePage(Page):
     subpage_types = []
 
     def get_context(self, request):
-        context = super(AllBooksHomePage, self).get_context(request)
-
-        all_posts = Book.objects.all().order_by("-date")
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllBooksHomePage,
+            Book
+        )
 
     class Meta:
         verbose_name = "Homepage for all Books"

--- a/event/models.py
+++ b/event/models.py
@@ -7,7 +7,7 @@ from wagtail.wagtailadmin.edit_handlers import FieldPanel
 
 from django.utils import timezone
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 
 class Event(Post):
@@ -56,12 +56,12 @@ class AllEventsHomePage(Page):
     subpage_types = ['Event']
 
     def get_context(self, request):
-        context = super(AllEventsHomePage, self).get_context(request)
-
-        all_posts = Event.objects.all().order_by("-date")
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllEventsHomePage,
+            Event
+        )
 
     class Meta:
         verbose_name = "Homepage for all Events"

--- a/event/templates/event/all_events_home_page.html
+++ b/event/templates/event/all_events_home_page.html
@@ -53,20 +53,22 @@
 
 	<div class="event-post-home-page">
 		<div class="content-grid__controls">
-			<div class="content-grid__controls__filter-group">
-				<div class="content-grid__controls__filter">
-					<select>
-						<option value="all">All Initiatives</option>
-						<option value="open">Open Technology Institute</option>
-						<option value="education">Education Policy</option>
-						<option value="asset">Asset Building</option>
-			        </select>
-			    </div>
-			    <div class="content-grid__controls__filter">
-					<input id="content-grid__controls__date-filter" class="date-picker" name="e1">
-			    </div>
-
-			</div>
+			<form action="{{ pageurl }}" method="get">
+				<div class="content-grid__controls__filter-group">
+					<div class="content-grid__controls__filter">
+						<select name="program_id">
+							<option value="">All Programs</option>
+							{% for program in programs %}
+							<option value="{{program.id}}">{{program.title}}</option>
+							{% endfor %}
+				        </select>
+				    </div>
+				    <div class="content-grid__controls__filter">
+						<input id="content-grid__controls__date-filter" class="date-picker" name="date">
+				    </div>
+				</div>
+					<input type="submit" value="Search">
+			</form>
 			<div class="content-grid__controls__right">
 				<div class="pagination">
 						{% if all_posts.has_previous %}

--- a/event/templates/event/program_events_page.html
+++ b/event/templates/event/program_events_page.html
@@ -54,20 +54,24 @@
 
 	<div class="event-post-home-page">
 		<div class="content-grid__controls">
-			<div class="content-grid__controls__filter-group">
-				<div class="content-grid__controls__filter">
-					<select>
-						<option value="all">All Initiatives</option>
-						<option value="open">Open Technology Institute</option>
-						<option value="education">Education Policy</option>
-						<option value="asset">Asset Building</option>
-			        </select>
-			    </div>
-				<div class="content-grid__controls__filter">
-					<input id="content-grid__controls__date-filter" class="date-picker" name="e1">
-			    </div>
-
-			</div>
+			{% if subprograms %}
+				<form action="{{ pageurl }}" method="get">
+					<div class="content-grid__controls__filter-group">
+						<div class="content-grid__controls__filter">
+							<select name="subprogram_id">
+								<option value="">All Initiatives</option>
+								{% for subprogram in subprograms %}
+								<option value="{{subprogram.id}}">{{subprogram.title}}</option>
+								{% endfor %}
+					        </select>
+					    </div>
+					    <div class="content-grid__controls__filter">
+							<input id="content-grid__controls__date-filter" class="date-picker" name="date">
+					    </div>
+					</div>
+						<input type="submit" value="Search">
+				</form>
+			{% endif %}
 			<div class="content-grid__controls__right">
 				<div class="pagination">
 						{% if all_posts.has_previous %}

--- a/home/templatetags/top_menu.py
+++ b/home/templatetags/top_menu.py
@@ -43,7 +43,7 @@ def top_menu(context, parent, calling_page=None):
         'location_programs': location_programs,
         # required by the pageurl tag that we want to use within this template
         'request': context['request'],
-        'program_logo': menu_program.mobile_program_logo
+        #'program_logo': menu_program.mobile_program_logo
     }
 
 

--- a/mysite/templates/org_post_home_page.html
+++ b/mysite/templates/org_post_home_page.html
@@ -35,20 +35,22 @@
 	</div>
 
 	<div class="content-grid__controls">
-		<div class="content-grid__controls__filter-group">
-			<div class="content-grid__controls__filter">
-				<select>
-					<option value="all">All Initiatives</option>
-					<option value="open">Open Technology Institute</option>
-					<option value="education">Education Policy</option>
-					<option value="asset">Asset Building</option>
-		        </select>
-		    </div>
-		    <div class="content-grid__controls__filter">
-				<input id="content-grid__controls__date-filter" class="date-picker" name="e1">
-		    </div>
-
-		</div>
+		<form action="{{ pageurl }}" method="get">
+			<div class="content-grid__controls__filter-group">
+				<div class="content-grid__controls__filter">
+					<select name="program_id">
+						<option value="">All Programs</option>
+						{% for program in programs %}
+						<option value="{{program.id}}">{{program.title}}</option>
+						{% endfor %}
+			        </select>
+			    </div>
+			    <div class="content-grid__controls__filter">
+					<input id="content-grid__controls__date-filter" class="date-picker" name="date">
+			    </div>
+			</div>
+				<input type="submit" value="Search">
+		</form>
 		<div class="content-grid__controls__right">
 			<div class="pagination">
 					{% if all_posts.has_previous %}

--- a/mysite/templates/program_post_home_page.html
+++ b/mysite/templates/program_post_home_page.html
@@ -34,9 +34,6 @@
 		</div>
 	</div>
 	
-	
-
-
 	<div class="content-grid__controls">
 	{% if subprograms %}
 	<form action="{{ pageurl }}" method="get">
@@ -56,7 +53,7 @@
 		</div>
 			<input type="submit" value="Search">
 
-			</form>
+	</form>
 	{% endif %}
 		<div class="content-grid__controls__right">
 			<div class="pagination">

--- a/podcast/models.py
+++ b/podcast/models.py
@@ -5,7 +5,7 @@ from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailembeds.blocks import EmbedBlock
 from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel, FieldPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 from django.db import models
 
@@ -41,12 +41,12 @@ class AllPodcastsHomePage(Page):
     subpage_types = []
 
     def get_context(self, request):
-        context = super(AllPodcastsHomePage, self).get_context(request)
-        all_posts = Podcast.objects.all().order_by("-date")
-
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllPodcastsHomePage,
+            Podcast
+        )
 
     class Meta:
         verbose_name = "Homepage for all Podcasts"

--- a/policy_paper/models.py
+++ b/policy_paper/models.py
@@ -9,7 +9,7 @@ from wagtail.wagtailcore.blocks import URLBlock
 from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 
 class PolicyPaper(Post):
@@ -53,12 +53,12 @@ class AllPolicyPapersHomePage(Page):
     subpage_types = []
 
     def get_context(self, request):
-        context = super(AllPolicyPapersHomePage, self).get_context(request)
-        all_posts = PolicyPaper.objects.all().order_by("-date")
-
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllPolicyPapersHomePage,
+            PolicyPaper
+        )
 
     class Meta:
         verbose_name = "Homepage for all Policy Papers"

--- a/press_release/models.py
+++ b/press_release/models.py
@@ -5,7 +5,7 @@ from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel
 from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 
 class PressRelease(Post):
@@ -35,12 +35,12 @@ class AllPressReleasesHomePage(Page):
     subpage_types = []
 
     def get_context(self, request):
-        context = super(AllPressReleasesHomePage, self).get_context(request)
-        all_posts = PressRelease.objects.all().order_by("-date")
-
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllPressReleasesHomePage,
+            PressRelease
+        )
 
     class Meta:
         verbose_name = "Homepage for all Press Releases"

--- a/quoted/models.py
+++ b/quoted/models.py
@@ -5,7 +5,7 @@ from home.models import Post
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs
+from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
 
 
 class Quoted(Post):
@@ -39,12 +39,12 @@ class AllQuotedHomePage(Page):
     subpage_types = []
 
     def get_context(self, request):
-        context = super(AllQuotedHomePage, self).get_context(request)
-        all_posts = Quoted.objects.all().order_by("-date")
-
-        context['all_posts'] = paginate_results(request, all_posts)
-
-        return context
+        return get_org_wide_posts(
+            self,
+            request,
+            AllQuotedHomePage,
+            Quoted
+        )
     
     class Meta:
         verbose_name = "Homepage for all In The News Pieces"


### PR DESCRIPTION
Allows filtering of content by date, program, or initiative on:
- Program content homepages (not events)
- Program event homepages
- Org wide content homepages (not events)
- Org wide event homepage

Also refactors the get context function for all org wide content homepages

[Resolves #620]

