### PR TITLE
Person ordering

### DIFF
--- a/person/models.py
+++ b/person/models.py
@@ -313,15 +313,15 @@ class ProgramPeoplePage(Page):
         if self.depth == 4:
             program_title = self.get_ancestors()[2]
             program = Program.objects.get(title=program_title)
-            all_posts = Person.objects.filter(
-                belongs_to_these_programs=program
-            )
+            all_posts = Person.objects\
+                .filter(belongs_to_these_programs=program)\
+                .order_by('last_name', 'first_name')
         else:
             subprogram_title = self.get_ancestors()[3]
             program = Subprogram.objects.get(title=subprogram_title)
-            all_posts = Person.objects.filter(
-                belongs_to_these_subprograms=program
-            )
+            all_posts = Person.objects\
+                .filter(belongs_to_these_subprograms=program)\
+                .order_by('last_name', 'first_name')
 
         context['people'] = paginate_results(request, all_posts)
 
@@ -361,9 +361,13 @@ class BoardAndLeadershipPeoplePage(Page):
         which_role = self.role_query
 
         if which_role == 'Leadership Team':
-            all_people = Person.objects.filter(leadership=True)
+            all_people = Person.objects\
+                .filter(leadership=True)\
+                .order_by('last_name', 'first_name')
         else:
-            all_people = Person.objects.filter(role=which_role)
+            all_people = Person.objects\
+                .filter(role=which_role)\
+                .order_by('last_name', 'first_name')
 
         context['people'] = paginate_results(request, all_people)
 

--- a/weekly/templates/weekly/weekly_article.html
+++ b/weekly/templates/weekly/weekly_article.html
@@ -90,8 +90,8 @@
 
 	<div class="post-container">
 
-	    {% if page.authors.all %}	
-		    <h5 class="post-author">{% generate_byline page.content_type page.authors.all %}</h5>
+	    {% if authors %}	
+		    <h5 class="post-author">{% generate_byline page.content_type authors %}</h5>
 		{% endif %}
 
 		<h5 class="post-date">{{ page.date }}</h5>
@@ -111,8 +111,8 @@
 		    {% endfor %}
 		</div>
 	    
-	    {% if page.authors.all %}
-		<h1 class="post-subheading">{% get_byline_prefix page.content_type page.authors.all %}</h1>
+	    {% if authors %}
+		<h1 class="post-subheading">{% get_byline_prefix page.content_type authors %}</h1>
 			{% for author in authors %}
 				{% if author.author.profile_image %}
 					<a href="{{ author.author.url }}">


### PR DESCRIPTION
- changed weekly article template to use context authors field - Resolves #739 
- ordered by last name for people query for program people page and leadership, board and central staff pages - Resolves #742 

