### PR TITLE
Person Conditionals

### DIFF
--- a/home/templatetags/utilities.py
+++ b/home/templatetags/utilities.py
@@ -172,3 +172,11 @@ def is_future(date):
 		return 1
 	else:
 		return 0
+
+@register.simple_tag()
+def person_display_contact_info(page):
+	if (page.email):
+		if (page.role != "External Author/Former Staff"):
+			return 1
+	
+	return 0

--- a/mysite/assets/scss/components/_content-entry.scss
+++ b/mysite/assets/scss/components/_content-entry.scss
@@ -86,6 +86,11 @@ $content-entry-text-gutter: 10px;
 			font-size:16px;
 			line-height: 150%;
 		}
+
+		&__person-position {
+			font-weight: bold;
+			line-height: 100%;
+		}
 	}
 
 	.post-person {

--- a/person/templates/person/person.html
+++ b/person/templates/person/person.html
@@ -38,9 +38,13 @@
         {% endif %}
     </div>
 
-    <div class="bio-page__contact">
-        <a class= "button" href="mailto:{{ page.email }}">Contact {{ page.first_name }} {{ page.last_name }}</a>
-    </div>
+    {% person_display_contact_info page as display_contact_info %}
+        {% if display_contact_info %}
+            <div class="bio-page__contact">
+                <a class= "button" href="mailto:{{ page.email }}">Contact {{ page.first_name }} {{ page.last_name }}</a>
+            </div>
+        {% endif %}
+  
 
     {% if featured_work.0.title %}
     <div class="bio-page__work">

--- a/person/templates/person/person.html
+++ b/person/templates/person/person.html
@@ -17,14 +17,18 @@
             </div>
             <div class="bio-page__heading__text">
                 <h1 class= "bio-page__heading__text__name">{{ page.first_name }} {{ page.last_name }}</h1>
-                <h3 class= "bio-page__heading__text__position">{{ page.position_at_new_america }}</h3>
+                {% if page.position_at_new_america %}
+                    <h3 class= "bio-page__heading__text__position">{{ page.position_at_new_america }}</h3>
+                {% endif %}
             </div>
         </div>
     {% else %}
         <div class="bio-page__heading">
             <div class="bio-page__heading__text">
                 <h1 class= "bio-page__heading__text__name">{{ page.first_name }} {{ page.last_name }}</h1>
-                <h3 class= "bio-page__heading__text__position">{{ page.position_at_new_america }}</h3>
+                {% if page.position_at_new_america %}
+                    <h3 class= "bio-page__heading__text__position">{{ page.position_at_new_america }}</h3>
+                {% endif %}
             </div>
         </div>
     {% endif %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -84,6 +84,8 @@
                                             <a href="{{ program.url }}"> {{ program | upper }}</a>{% list_separator forloop.revcounter0 %}
                                         {% endfor %}
                                         PERSON</h5>
+                                    {% else %}
+                                        <h5 class="content-entry__text__program">PERSON</h5>
                                     {% endif %}
                                     <h5 class= "content-entry__text__title"><a href="{{ post.specific.url }}">{{ post.specific.first_name }} {{ post.specific.last_name }}</a></h5>
 

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -89,7 +89,11 @@
                                     {% endif %}
                                     <h5 class= "content-entry__text__title"><a href="{{ post.specific.url }}">{{ post.specific.first_name }} {{ post.specific.last_name }}</a></h5>
 
-                                    {{ post.specific.short_bio | richtext }}
+                                    {% if post.specific.short_bio %}
+                                        {{ post.specific.short_bio | richtext }}
+                                    {% elif post.specific.position_at_new_america %}
+                                        <h5 class= "content-entry__text__person-position">{{ post.specific.position_at_new_america }}</h5>
+                                    {% endif %}
                                 </div>
                             </div>
                         {% else %}
@@ -106,7 +110,11 @@
                                     {% endif %}
                                     <h5 class= "content-entry__text__title"><a href="{{ post.specific.url }}">{{ post.specific.first_name }} {{ post.specific.last_name }}</a></h5>
 
-                                    {{ post.specific.short_bio | richtext }}
+                                    {% if post.specific.short_bio %}
+                                        {{ post.specific.short_bio | richtext }}
+                                    {% elif post.specific.position_at_new_america %}
+                                         <h5 class= "content-entry__text__person-position">{{ post.specific.position_at_new_america }}</h5>
+                                    {% endif %}
                                 </div>
                             </div>
                         {% endif %}


### PR DESCRIPTION
- Added conditional to eliminate 'None' in position line in bio from content transfer
- added conditional to display contact info on bio page if person has an email and is not former staff/external author
Resolves #770 

- added fallbacks in search results page to show person title if no short bio and 'Person' page type with or without image
Resolves #766 