### PR TITLE
Refactored top menu template tag and updated query to exclude location based programs

### DIFF
--- a/home/templatetags/top_menu.py
+++ b/home/templatetags/top_menu.py
@@ -20,20 +20,11 @@ def has_menu_children(page):
 # Retrieves the top menu items - the immediate children of the parent page
 @register.inclusion_tag('tags/top_menu.html', takes_context=True)
 def top_menu(context, parent, calling_page=None):
-    # programs = Program.objects.in_menu().order_by("title").exclude(location=True)
-    programs = []
-    location_programs = []
-    all_programs = Program.objects.in_menu().order_by("title")
-    for program in all_programs:
-        if program.location == True:
-            location_programs.append(program)
-        else:
-            programs.append(program)
+    all_programs = Program.objects.in_menu().order_by("title").exclude(location=True)
 
     return {
         'calling_page': calling_page,
-        'programs': programs,
-        'location_programs': location_programs,
+        'programs': all_programs,
         # required by the pageurl tag that we want to use within this template
         'request': context['request'],
     }


### PR DESCRIPTION
- Need to select "show in menus" for location based programs to appear in the Program drop down
- This PR refactors and updates the template tag for the top menu to exclude the location based programs based programs based on the location field but then allows us to use "show in menus" to show them elsewhere on the site

[Resolves #915]