### PR TITLE
Mini Mobile Nav Logo

### DIFF
--- a/mysite/assets/scss/mixins/_breakpoints.scss
+++ b/mysite/assets/scss/mixins/_breakpoints.scss
@@ -35,3 +35,11 @@
     @content;
   }
 }
+
+@mixin show-mini-logo {
+  .has_sidemenu & {
+    @media screen and (max-width: $mini-logo-breakpoint) {
+      @content;
+    }
+  }
+}

--- a/mysite/assets/scss/mixins/_breakpoints.scss
+++ b/mysite/assets/scss/mixins/_breakpoints.scss
@@ -37,7 +37,7 @@
 }
 
 @mixin show-mini-logo {
-  .has_sidemenu & {
+  @include has-sidemenu {
     @media screen and (max-width: $mini-logo-breakpoint) {
       @content;
     }

--- a/mysite/assets/scss/modules/header/_logo.scss
+++ b/mysite/assets/scss/modules/header/_logo.scss
@@ -1,11 +1,3 @@
-@mixin show-mini-logo {
-  .has_sidemenu & {
-    @media screen and (max-width: $mini-logo-breakpoint) {
-      @content;
-    }
-  }
-}
-
 .header__logo {
   width: $mobile-logo-width;
   display: inline-block;

--- a/mysite/assets/scss/modules/mobile-nav/_main.scss
+++ b/mysite/assets/scss/modules/mobile-nav/_main.scss
@@ -32,7 +32,7 @@ $mobile-nav-toggle-offset: 35px;
     }
 
     @include show-mini-logo {
-      width: 37% !important;
+      width: 35% !important;
     }
     
   }
@@ -50,7 +50,7 @@ $mobile-nav-toggle-offset: 35px;
     }
 
     @include show-mini-logo {
-      width: 63%;
+      width: 65%;
     }
 
     &__logo-fallback {

--- a/mysite/assets/scss/modules/mobile-nav/_main.scss
+++ b/mysite/assets/scss/modules/mobile-nav/_main.scss
@@ -30,6 +30,11 @@ $mobile-nav-toggle-offset: 35px;
       width: 50%;
       float:left;
     }
+
+    @include show-mini-logo {
+      width: 37% !important;
+    }
+    
   }
 
   &__secondary {
@@ -42,6 +47,10 @@ $mobile-nav-toggle-offset: 35px;
 
     @include has-sidemenu {
       display:block;
+    }
+
+    @include show-mini-logo {
+      width: 63%;
     }
 
     &__logo-fallback {


### PR DESCRIPTION
- Set mobile nav to be 35-65% to accomodate large program logos on very small screens #858 
- Set mini program logo to not show up on pages with simple sidemenus (weekly, org-wide simple pages) #928 