### PR TITLE
Social Share - Handle Quotes in Titles

### DIFF
--- a/mysite/templates/ui_elements/social_share.html
+++ b/mysite/templates/ui_elements/social_share.html
@@ -3,7 +3,7 @@
     $("#share").jsSocials({
     	showCount: true,
 		showLabel: true,
-		text: "{{ page.title|safe|escapejs }}",
+		text: "{{ page.title|escapejs }}",
 		shareIn: "popup",
         shares: [
         	{

--- a/mysite/templates/ui_elements/social_share.html
+++ b/mysite/templates/ui_elements/social_share.html
@@ -3,7 +3,7 @@
     $("#share").jsSocials({
     	showCount: true,
 		showLabel: true,
-		text: "{{ page.title | safe }}",
+		text: "{{ page.title|safe|escapejs }}",
 		shareIn: "popup",
         shares: [
         	{


### PR DESCRIPTION
- escaped title text in social share to avoid conflicts with quotes - Resolves #954 