### PR TITLE
Restructure Events Home Page Setup

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -5,7 +5,7 @@ from home.models import Post
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
+from mysite.helpers import paginate_results, get_program_and_subprogram_posts, get_org_wide_posts
 
 
 class Article(Post):
@@ -61,7 +61,7 @@ class ProgramArticlesPage(Page):
     subpage_types = ['Article']
 
     def get_context(self, request):
-        return get_posts_and_programs(
+        return get_program_and_subprogram_posts(
             self,
             request,
             ProgramArticlesPage,

--- a/blog/models.py
+++ b/blog/models.py
@@ -9,7 +9,7 @@ from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
+from mysite.helpers import paginate_results, get_program_and_subprogram_posts, get_org_wide_posts
 
 
 class BlogPost(Post):
@@ -85,7 +85,7 @@ class ProgramBlogPostsPage(Page):
     ]
 
     def get_context(self, request):
-        return get_posts_and_programs(
+        return get_program_and_subprogram_posts(
             self,
             request,
             ProgramBlogPostsPage,

--- a/book/models.py
+++ b/book/models.py
@@ -5,7 +5,7 @@ from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
 from home.models import Post
 
-from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
+from mysite.helpers import paginate_results, get_program_and_subprogram_posts, get_org_wide_posts
 
 
 class Book(Post):
@@ -58,7 +58,7 @@ class ProgramBooksPage(Page):
     subpage_types = ['Book']
     
     def get_context(self, request):
-        return get_posts_and_programs(self, request, ProgramBooksPage, Book)
+        return get_program_and_subprogram_posts(self, request, ProgramBooksPage, Book)
 
     class Meta:
         verbose_name = "Books Homepage for Program and Subprogram"

--- a/event/models.py
+++ b/event/models.py
@@ -6,14 +6,10 @@ from wagtail.wagtailcore.models import Page
 from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 
-from django.http import HttpResponse
 from django.template.response import TemplateResponse
-from datetime import datetime
-from pytz import timezone
-
 from django.utils import timezone
 
-from mysite.helpers import paginate_results, get_org_wide_events, get_program_and_subprogram_events
+from mysite.helpers import paginate_results, get_program_and_subprogram_events, get_org_wide_events
 
 
 class Event(Post):
@@ -63,6 +59,7 @@ class AllEventsHomePage(RoutablePageMixin, Page):
 
     @route(r'^$')
     def future_events(self, request):
+        self.title = "Future " + self.title
         return TemplateResponse(
             request,
             self.get_template(request),
@@ -92,6 +89,7 @@ class ProgramEventsPage(RoutablePageMixin, Page):
 
     @route(r'^$')
     def future_events(self, request):
+        self.title = "Future " + self.title
         return TemplateResponse(
             request,
             self.get_template(request),
@@ -101,7 +99,6 @@ class ProgramEventsPage(RoutablePageMixin, Page):
     @route(r'^past/$')
     def past_events(self, request):
         self.title = "Past " + self.title
-        
         return TemplateResponse(
             request,
             self.get_template(request),

--- a/event/models.py
+++ b/event/models.py
@@ -71,6 +71,7 @@ class AllEventsHomePage(RoutablePageMixin, Page):
 
     @route(r'^past/$')
     def past_events(self, request):
+        self.title = "Past " + self.title
         return TemplateResponse(
             request,
             self.get_template(request),
@@ -99,6 +100,8 @@ class ProgramEventsPage(RoutablePageMixin, Page):
 
     @route(r'^past/$')
     def past_events(self, request):
+        self.title = "Past " + self.title
+        
         return TemplateResponse(
             request,
             self.get_template(request),

--- a/home/templates/tags/side_menu.html
+++ b/home/templates/tags/side_menu.html
@@ -16,7 +16,7 @@
             </ul>
           </li>
         {% endif %}
-        <li class="mobile-menu__link__main"><a href='{{ side_menu.url }}{% get_event_url "program" "future" %}'>Events</a></li>
+        <li class="mobile-menu__link__main"><a href='{{ side_menu.url }}events/'>Events</a></li>
         {% if side_menu.work_pages %}
           <li class="mobile-menu__link__main"><a href="#">Publications</a>
               <div class="mobile-menu__toggle flip-arrow-white rotate"></div>
@@ -61,8 +61,8 @@
       {% endif %}
 
       <li class="menu-text sidemenu__link-group__title">Events</li>
-        <li class="sidemenu__link-group__link"><a href='{{ side_menu.url }}{% get_event_url "program" "future" %}'>Future Events</a></li>
-        <li class="sidemenu__link-group__link"><a href='{{ side_menu.url }}{% get_event_url "program" "past" %}'>Past Events</a></li>
+        <li class="sidemenu__link-group__link"><a href='{{ side_menu.url }}events/'>Future Events</a></li>
+        <li class="sidemenu__link-group__link"><a href='{{ side_menu.url }}events/past/'>Past Events</a></li>
 
       {% if side_menu.work_pages %}
         <li class="menu-text sidemenu__link-group__title">Publications</li>

--- a/home/templates/tags/side_menu.html
+++ b/home/templates/tags/side_menu.html
@@ -16,7 +16,13 @@
             </ul>
           </li>
         {% endif %}
-        <li class="mobile-menu__link__main"><a href='{{ side_menu.url }}events/'>Events</a></li>
+         <li class="mobile-menu__link__main"><a href="#">Events</a>
+              <div class="mobile-menu__toggle flip-arrow-white rotate"></div>
+              <ul class="vertical menu">
+                <li class="mobile-menu__link__secondary"><a href="{{ side_menu.url }}events/">Future Events</a></li>
+                <li class="mobile-menu__link__secondary"><a href="{{ side_menu.url }}events/past/">Past Events</a></li>
+              </ul>
+          </li>
         {% if side_menu.work_pages %}
           <li class="mobile-menu__link__main"><a href="#">Publications</a>
               <div class="mobile-menu__toggle flip-arrow-white rotate"></div>

--- a/home/templates/tags/top_menu.html
+++ b/home/templates/tags/top_menu.html
@@ -28,7 +28,7 @@
                 <li class="mobile-menu__link__secondary"><a href="http://www.slate.com/articles/technology/future_tense.html">Future Tense on Slate</a></li>
             </ul>
         </li>
-        <li class="mobile-menu__link__main"><a href='{% get_event_url "org" "future" %}'>Events</a></li>
+        <li class="mobile-menu__link__main"><a href="/events/">Events</a></li>
         <li class="mobile-menu__link__main"><a href="#">Publications</a>
             <div class="mobile-menu__toggle flip-arrow-black rotate"></div>
             <ul class="vertical menu">
@@ -152,7 +152,7 @@
                 </li>
 
                 <li class='header__main-nav__item'>
-                    <a class='header__button button' href='{% get_event_url "org" "future" %}'>Events</a>
+                    <a class='header__button button' href='/events/'>Events</a>
                 </li>
                 <li class='header__main-nav__simple-link-group-item header__has-link-group'>
                     <a class='header__button header__button--dropdown button'>Publications</a>

--- a/home/templates/tags/top_menu.html
+++ b/home/templates/tags/top_menu.html
@@ -28,7 +28,13 @@
                 <li class="mobile-menu__link__secondary"><a href="http://www.slate.com/articles/technology/future_tense.html">Future Tense on Slate</a></li>
             </ul>
         </li>
-        <li class="mobile-menu__link__main"><a href="/events/">Events</a></li>
+        <li class="mobile-menu__link__main"><a href="#">Events</a>
+            <div class="mobile-menu__toggle flip-arrow-black rotate"></div>
+            <ul class="vertical menu">
+                <li class="mobile-menu__link__secondary"><a href="/events/">Future Events</a></li>
+                <li class="mobile-menu__link__secondary"><a href="/events/past/">Past Events</a></li>
+            </ul>
+        </li>
         <li class="mobile-menu__link__main"><a href="#">Publications</a>
             <div class="mobile-menu__toggle flip-arrow-black rotate"></div>
             <ul class="vertical menu">

--- a/home/templatetags/utilities.py
+++ b/home/templatetags/utilities.py
@@ -143,36 +143,6 @@ def generate_dateline(post):
 
 	return mark_safe(ret_string)
 
-
-# generates event url with query parameters
-# 	level: determines whether it is at the org wide or program wide level
-#	tense: determines whether it will return past or future events
-@register.simple_tag()
-def get_event_url(level, tense):
-	datetime_format = "%Y-%m-%d"
-	eastern = timezone('US/Eastern')
-
-	if (tense == "past"):
-		start_date = (datetime.now(eastern) - timedelta(days=7)).strftime(datetime_format)
-		end_date = datetime.now(eastern).strftime(datetime_format)
-	else:
-		start_date = datetime.now(eastern).strftime(datetime_format)
-		end_date = (datetime.now(eastern) + timedelta(days=365)).strftime(datetime_format)
-
-	if (level == "org"):
-		ret_string = '/events/?program_id'
-	else:
-		ret_string = 'events/?subprogram_id'
-
-	# generates string uri encoding of query object
-	ret_string += '=&date=%7B"start"%3A"'
-	ret_string += start_date
-	ret_string += '"%2C"end"%3A"'
-	ret_string += end_date
-	ret_string += '"%7D'
-	
-	return ret_string
-
 # calls helper function to determine if date/time are future or past, depending if event is single day or multi-day
 # 	- single day events are considered past at the start time on the day of the event (start_date + start_time)
 # 	- multi-day events are considered past at the start time on the final day of the event (end_date + start_time)

--- a/mysite/helpers.py
+++ b/mysite/helpers.py
@@ -2,6 +2,10 @@ import json
 
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.http import QueryDict
+from django.db.models import Q
+
+from datetime import datetime, timedelta
+from pytz import timezone
 
 from programs.models import Program, Subprogram
 
@@ -42,13 +46,49 @@ def get_org_wide_posts(self, request, page_type, content_model):
 
     all_posts = content_model.objects.filter(**filter_dict)
     context['all_posts'] = paginate_results(request, all_posts.live().order_by("-date"))
-    context['all_events'] = paginate_results(request, all_posts.live().order_by("date", "start_time"))
     context['programs'] = Program.objects.all().live().in_menu().order_by('title')
     context['query_url'] = generate_url(request)
+    
+    return context
+
+def get_org_wide_events(self, request, page_type, content_model, tense):
+    """
+    Function to return a list of content 
+    for org wide content homepage.
+
+    Also checks if there is a query to filter content by initiatives
+    or by date for programs.
+    """
+    context = super(page_type, self).get_context(request)
+
+    search_program = request.GET.get('program_id', None)
+    date = request.GET.get('date', None)
+
+    date_query = Q()
+    program_query = Q()
+    
+    if search_program:
+        program_query = Q(parent_programs__exact=int(search_program))
+    
+    if date:
+        date_range = json.loads(date)
+        date_query = Q(date__range=(date_range['start'], date_range['end']))
+    else:
+        date_query = set_default_date_query(tense)
+    
+    all_events = content_model.objects.filter(date_query & program_query)
+    if (tense == "future"):
+        context['all_events'] = paginate_results(request, all_events.live().order_by("date", "start_time"))
+    else:
+        context['all_events'] = paginate_results(request, all_events.live().order_by("-date", "-start_time"))
+    
+    context['programs'] = Program.objects.all().live().in_menu().order_by('title')
+    context['query_url'] = generate_url(request)
+
     return context
 
 
-def get_posts_and_programs(self, request, page_type, content_model):
+def get_program_and_subprogram_posts(self, request, page_type, content_model):
     """
     Function to return a list of content for a program or 
     subprogram content homepage.
@@ -58,10 +98,10 @@ def get_posts_and_programs(self, request, page_type, content_model):
     """
     context = super(page_type, self).get_context(request)
 
-    page = request.GET.get('page', 1)
     search_subprogram = request.GET.get('subprogram_id', None)
     date = request.GET.get('date', None)
 
+    # program grid
     if self.depth == 4:
         program_title = self.get_ancestors()[2]
         program = Program.objects.get(title=program_title)
@@ -75,6 +115,7 @@ def get_posts_and_programs(self, request, page_type, content_model):
     
         all_posts = content_model.objects.live().filter(**filter_dict)
         context['subprograms'] = program.get_children().type(Subprogram).live().order_by('title')
+    # subprogram_grid
     else:
         subprogram_title = self.get_ancestors()[3]
         program = Subprogram.objects.get(title=subprogram_title)
@@ -87,6 +128,71 @@ def get_posts_and_programs(self, request, page_type, content_model):
     context['query_url'] = generate_url(request)
     
     return context
+
+def get_program_and_subprogram_events(self, request, page_type, content_model, tense):
+    """
+    Function to return a list of content for a program or 
+    subprogram content homepage.
+
+    Also checks if there is a query to filter content by initiatives
+    or by date for programs.
+    """
+
+    print("in get programs and subprograms!")
+    context = super(page_type, self).get_context(request)
+
+    search_subprogram = request.GET.get('subprogram_id', None)
+    date = request.GET.get('date', None)
+
+    date_query = Q()
+    program_query = Q()
+    subprogram_query = Q()
+
+    # if program grid
+    if self.depth == 4:
+        program_title = self.get_ancestors()[2]
+        program = Program.objects.get(title=program_title)
+
+        program_query = Q(parent_programs__exact=program)
+        if search_subprogram:
+            subprogram_query = Q(post_subprogram__exact=int(search_subprogram))
+
+        context['subprograms'] = program.get_children().type(Subprogram).live().order_by('title')
+    # if subprogram grid
+    else:
+        subprogram_title = self.get_ancestors()[3]
+        program = Subprogram.objects.get(title=subprogram_title)
+
+        subprogram_query = Q(post_subprogram__exact=int(search_subprogram))
+
+    if date:
+        date_range = json.loads(date)
+        date_query = Q(date__range=(date_range['start'], date_range['end']))
+    else:
+        date_query = set_default_date_query(tense)
+
+    all_events = content_model.objects.live().filter(date_query & program_query & subprogram_query)
+    print("here!")
+    print(all_events)
+    if (tense == "future"):
+        context['all_events'] = paginate_results(request, all_events.live().order_by("date", "start_time"))
+    else:
+        context['all_events'] = paginate_results(request, all_events.live().order_by("-date", "-start_time"))
+
+    context['program'] = program
+    context['query_url'] = generate_url(request)
+    
+    return context
+
+def set_default_date_query(tense):
+    datetime_format = "%Y-%m-%d"
+    eastern = timezone('US/Eastern')
+    curr_date = datetime.now(eastern).date().strftime(datetime_format)
+
+    if (tense == "future"):
+        return Q(date__gte=curr_date) | Q(end_date__gte=curr_date)
+    else:
+        return Q(date__lt=curr_date) & (Q(end_date__isnull=True) | Q(end_date__lt=curr_date))
 
 def generate_url(request):
     query = QueryDict(mutable=True)

--- a/mysite/templates/events_sidemenu.html
+++ b/mysite/templates/events_sidemenu.html
@@ -10,8 +10,8 @@
 		<div class="sidemenu__link-group">
 			<ul class="menu vertical sidemenu__link-group__content">
 			  <li class="menu-text sidemenu__link-group__title">Events</li>
-			  <li class="sidemenu__link-group__link"><a href='{% get_event_url "org" "future" %}'>Future Events</a></li>
-			  <li class="sidemenu__link-group__link"><a href='{% get_event_url "org" "past" %}'>Past Events</a></li>
+			  <li class="sidemenu__link-group__link"><a href='/events/'>Future Events</a></li>
+			  <li class="sidemenu__link-group__link"><a href='/events/past/'>Past Events</a></li>
 			</ul>
 		</div>
 	</div>

--- a/podcast/models.py
+++ b/podcast/models.py
@@ -5,7 +5,7 @@ from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailembeds.blocks import EmbedBlock
 from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel, FieldPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
+from mysite.helpers import paginate_results, get_program_and_subprogram_posts, get_org_wide_posts
 
 from django.db import models
 
@@ -63,7 +63,7 @@ class ProgramPodcastsPage(Page):
     subpage_types = ['Podcast']
 
     def get_context(self, request):
-        return get_posts_and_programs(
+        return get_program_and_subprogram_posts(
             self,
             request,
             ProgramPodcastsPage,

--- a/policy_paper/models.py
+++ b/policy_paper/models.py
@@ -9,7 +9,7 @@ from wagtail.wagtailcore.blocks import URLBlock
 from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
+from mysite.helpers import paginate_results, get_program_and_subprogram_posts, get_org_wide_posts
 
 
 class PolicyPaper(Post):
@@ -73,7 +73,7 @@ class ProgramPolicyPapersPage(Page):
     subpage_types = ['PolicyPaper']
 
     def get_context(self, request):
-        return get_posts_and_programs(
+        return get_program_and_subprogram_posts(
             self,
             request,
             ProgramPolicyPapersPage,

--- a/press_release/models.py
+++ b/press_release/models.py
@@ -5,7 +5,7 @@ from wagtail.wagtailcore.fields import StreamField
 from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel
 from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 
-from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
+from mysite.helpers import paginate_results, get_program_and_subprogram_posts, get_org_wide_posts
 
 
 class PressRelease(Post):
@@ -56,7 +56,7 @@ class ProgramPressReleasesPage(Page):
     subpage_types = ['PressRelease']
 
     def get_context(self, request):
-        return get_posts_and_programs(
+        return get_program_and_subprogram_posts(
             self,
             request,
             ProgramPressReleasesPage,

--- a/quoted/models.py
+++ b/quoted/models.py
@@ -5,7 +5,7 @@ from home.models import Post
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 
-from mysite.helpers import paginate_results, get_posts_and_programs, get_org_wide_posts
+from mysite.helpers import paginate_results, get_program_and_subprogram_posts, get_org_wide_posts
 
 
 class Quoted(Post):
@@ -60,7 +60,7 @@ class ProgramQuotedPage(Page):
     subpage_types = ['Quoted']
 
     def get_context(self, request):
-        return get_posts_and_programs(
+        return get_program_and_subprogram_posts(
             self,
             request,
             ProgramQuotedPage,


### PR DESCRIPTION
- implemented separate views for future and past events pages (for both org-wide and program events homepages)
- Set links in header, sidemenus, and mobile menus to new event urls

Resolves #837 #863