### PR TITLE
Settings changes to fix for scheduling and file upload issues

### DIFF
--- a/custom_storages.py
+++ b/custom_storages.py
@@ -7,3 +7,4 @@ class StaticStorage(S3BotoStorage):
 
 class MediaStorage(S3BotoStorage):
     bucket_name = settings.MEDIA_BUCKET_NAME
+    file_overwrite = False

--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -19,18 +19,6 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
-ALLOWED_HOSTS = ['*']
-
-SECRET_KEY = os.getenv("SECRET_KEY")
-
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
-
-
-# Application definition
-
-
 INSTALLED_APPS = [
     'home',
     'search',

--- a/mysite/settings/dev.py
+++ b/mysite/settings/dev.py
@@ -11,6 +11,9 @@ for template_engine in TEMPLATES:
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("SECRET_KEY")
 
+# Timezone settings
+TIME_ZONE = 'America/New_York'
+USE_TZ = True
 
 try:
     from .local import *

--- a/mysite/settings/production.py
+++ b/mysite/settings/production.py
@@ -2,6 +2,11 @@ from .base import *
 
 import os
 
+# Timezone settings
+TIME_ZONE = 'America/New_York'
+USE_TZ = True
+
+
 DEBUG = False
 
 APPEND_SLASH = True
@@ -9,7 +14,7 @@ APPEND_SLASH = True
 SECRET_KEY = os.getenv("SECRET_KEY")
 
 # Will be changed to final host url
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ['na-staging.herokuapp.com', 'newamerica.org']
 
 AWS_QUERYSTRING_AUTH = False
 
@@ -46,7 +51,7 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 
-# Email backend configuration 
+# Email backend configuration
 EMAIL_BACKEND = 'postmark.django_backend.EmailBackend'
 POSTMARK_API_KEY = os.getenv("POSTMARK_API_KEY")
 POSTMARK_SENDER = os.getenv("POSTMARK_SENDER")


### PR DESCRIPTION
These are two substantial bug fixes so adding some documentation here in case they need to be revisited at some point. 

- Solution for publishing scheduled pages - set up Heroku scheduler to run ```python manage.py publish_schedule_pages``` command every 10 minutes. **Need to relay that to comms and program staff.** This means if a page is scheduled for 9:32 a.m. - it will be published at 9:40. And likewise a page scheduled for 9:28 will go up at 9:30. cc: @rossvanderlinde @kjacks 

- Solution for file upload issue - Bug within django-storages doesn't prevent users from uploading a file with the same name. Solution in place is to prevent the s3 file from being overwritten by setting ```file_overwrite = False``` in our media custom storages file.  For users, this means if you upload a file called "OurPaper.pdf" and it changes and needs to be updated then you'll need to first delete that original file and then re-upload the new version of "OurPaper.pdf". If you were to add "OurPaper.pdf" again, it would change the file path to something like "OurPaper1234.pdf" so that it's a unique path. 

[Resolves #976] 
[Resolves #1016]