### PR TITLE
Set Max Width for Table Block

### DIFF
--- a/mysite/assets/scss/components/_post-body.scss
+++ b/mysite/assets/scss/components/_post-body.scss
@@ -224,7 +224,7 @@
   }
 
   .block-table {
-    max-width: 100%;
+    max-width: $max-site-width - $max-sidemenu-width;
     margin-top: $desktop-padding;
     margin-bottom: $desktop-padding;
     overflow-x: scroll;


### PR DESCRIPTION
- prevents table block from breaking post layout

ex. http://www.newamerica.org/education-policy/edcentral/why-default-rates-arent-enough/