### PR TITLE
Images url endpoint

### DIFF
--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
+from wagtail.wagtailimages import urls as wagtailimages_urls
 
 from rss_feed.feeds import GenericFeed, ContentFeed, AuthorFeed, ProgramFeed, SubprogramFeed, EventFeed, EventProgramFeed
 
@@ -14,6 +15,7 @@ urlpatterns = [
 
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'^images/', include(wagtailimages_urls)),
 
     url(r'^search/$', 'search.views.search', name='search'),
 


### PR DESCRIPTION
- sets images url endpoint so that images uploaded to the site can be accessed externally 

reference: http://docs.wagtail.io/en/v1.0b2/reference/images/using_images_outside_wagtail.html