### PR TITLE
SSL redirect in Django Settings

### DIFF
--- a/mysite/settings/production.py
+++ b/mysite/settings/production.py
@@ -18,6 +18,9 @@ ADMINS = [('Kirk', 'jackson@newamerica.org'), ('Andrew', 'lomax@newamerica.org')
 # Will be changed to final host url
 ALLOWED_HOSTS = ['*']
 
+SECURE_SSL_REDIRECT = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 AWS_QUERYSTRING_AUTH = False
 
 # s3 bucket settings


### PR DESCRIPTION
addresses #1218 

@rschulman , looks like a simple [Django settings tweak](https://docs.djangoproject.com/en/dev/ref/settings/#secure-ssl-redirect) is all we need. 

The [SECURE_PROXY_SSL_HEADER](https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header) is apparently necessary for Heroku instances...but Django docs warn "Obviously, you should only set this setting if you control your proxy or have some other guarantee that it sets/strips this header appropriately." 

Here's Heroku's [documentation](https://devcenter.heroku.com/articles/http-routing#routing) on how they route requests, so it looks like we can reasonably trust that the header is being set appropriately by Heroku... are there any other considerations?