### PR TITLE
Downgrade Elasticsearch-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ dockerpty==0.4.1
 docopt==0.6.2
 docutils==0.12
 drf-nested-routers==0.9.0
-elasticsearch==1.9.0
+elasticsearch==1.7.0
 elasticutils==0.8.2
 Embedly==0.5.0
 factory-boy==2.4.1


### PR DESCRIPTION
addressing #1244

Can't think of a way to test this outside of production since error is not replicable in staging or locally. Downgrading elasticsearch to match Searchbox's version.