### PR TITLE
Smaller Soundcloud Embed on Podcasts

### DIFF
--- a/mysite/assets/js/modules/post-body/index.js
+++ b/mysite/assets/js/modules/post-body/index.js
@@ -71,10 +71,24 @@ function readMoreInteraction() {
 	});
 }
 
+// hack to use smaller soundcloud embed
+//...wagtail uses oembed call that is not customizable
+function swapSoundCloudEmbed() {
+	let sc = $('.block-soundcloud_embed').find('iframe');
+	if( sc.attr('src') ){
+		let src = sc.attr('src');
+		if( src.match( /.*(soundcloud).*(visual=true)/ ))
+			sc.attr('src', src.replace( 'visual=true', '' ));
+	}
+	// give DOM half a beat to reload soundcloud src
+	setTimeout( function(){ sc.addClass('loaded'); }, 50 );
+}
+
 export default function() {
 	checkDropcap();
 	convertToHttps();
 	addDatavizDownloadInteractivity();
 	resizeTableBlock();
 	readMoreInteraction();
+	swapSoundCloudEmbed()
 }

--- a/mysite/assets/scss/components/_post-body.scss
+++ b/mysite/assets/scss/components/_post-body.scss
@@ -399,6 +399,18 @@
 .post-soundcloud {
   margin-bottom: 20px;
 
+  .block-soundcloud_embed iframe {
+    opacity: 0;
+    transition: 0.35s opacity ease-in;
+    -webkit-transition: 0.35s opacity ease-in;
+    -moz-transition: 0.35s opacity ease-in;
+    -o-transition: 0.35s opacity ease-in;
+
+    &.loaded{
+      opacity: 1;
+    }
+  }
+
   iframe {
     height: 180px;
   }

--- a/podcast/templates/podcast/podcast.html
+++ b/podcast/templates/podcast/podcast.html
@@ -14,7 +14,7 @@
 			<div class="post-header with-image" style="background-image: linear-gradient(
 			      rgba(0, 0, 0, 0),
 			      rgba(0, 0, 0, 0.15)
-			    ), 
+			    ),
 		    	url({{ story_image.url }})">
 
 				<div class="post-header__text">
@@ -55,7 +55,7 @@
 	    {% for block in self.body %}
 	    	{% include 'ui_elements/post_body_block.html' %}
 	    {% endfor %}
-	
+
 		{% if page.itunes_url %}
 			<a href="{{ page.itunes_url }}">Listen on iTunes</a>
 		{% endif %}


### PR DESCRIPTION
preference from Maria and John. Wagtail uses soundcloud/oembed call that is not customizable. JS hack to replace "visual=true" param in markup after render. Not ideal, but only option I think.