### PR TITLE
Logging

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -453,6 +453,8 @@ class Post(Page):
     def get_context(self, request):
         context = super(Post, self).get_context(request)
         context['authors'] = self.authors.order_by('pk')
+        i = "akjg9235023ag***"
+        break_this = int(i)
 
         return context
 

--- a/home/models.py
+++ b/home/models.py
@@ -453,8 +453,6 @@ class Post(Page):
     def get_context(self, request):
         context = super(Post, self).get_context(request)
         context['authors'] = self.authors.order_by('pk')
-        i = "akjg9235023ag***"
-        break_this = int(i)
 
         return context
 

--- a/mysite/log_handlers.py
+++ b/mysite/log_handlers.py
@@ -1,0 +1,37 @@
+import logging, traceback, os
+from logdna import LogDNAHandler as LogDNA
+
+class LogDNAHandler(logging.StreamHandler):
+    def emit(self, record):
+        try:
+            API_KEY = os.getenv('LOGDNA_KEY')
+            handler = LogDNA(API_KEY,{
+                'index_meta': True,
+                'app': 'newamerica-cms',
+                'level': 'Error',
+                'hostname': os.getenv('HOSTNAME') or 'na-errors'
+            })
+            log = logging.getLogger('logdna')
+            log.addHandler(handler)
+            if record:
+
+                if record.exc_info is not None:
+                    exc_type, exc_val, exc_tb = record.exc_info
+                    tb = traceback.extract_tb(exc_tb)
+                    cause = tb[len(tb)-1]
+
+                    filename = cause[0]
+                    line = cause[1]
+                    msg = traceback.format_exception_only(exc_type, exc_val)[0].replace('\n','; ')
+
+                    error = 'file=%s line=%s msg="%s"' % (filename, line, msg)
+                    context = {
+                        'traceback': traceback.format_tb(exc_tb)
+                    }
+
+                    log.error(error, {'context':context})
+
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)

--- a/mysite/log_handlers.py
+++ b/mysite/log_handlers.py
@@ -1,4 +1,4 @@
-import logging, traceback, os
+import logging, traceback, os, sys
 from logdna import LogDNAHandler as LogDNA
 
 class LogDNAMiddleware(object):
@@ -19,27 +19,23 @@ class LogDNAMiddleware(object):
         response = self.get_response(request)
         return response
 
-    def process_exception(request, exception):
-        print exception
-        try:
-            if record:
-                if record.exc_info is not None:
-                    exc_type, exc_val, exc_tb = record.exc_info
-                    tb = traceback.extract_tb(exc_tb)
-                    cause = tb[len(tb)-1]
+    def process_exception(self, request, exception):
+        exc_info = sys.exc_info()
 
-                    filename = cause[0]
-                    line = cause[1]
-                    msg = traceback.format_exception_only(exc_type, exc_val)[0].replace('\n','; ')
+        exc_type, exc_val, exc_tb = exc_info
+        tb = traceback.extract_tb(exc_tb)
+        cause = tb[len(tb)-1]
 
-                    error = 'file=%s line=%s msg="%s"' % (filename, line, msg)
-                    context = {
-                        'traceback': traceback.format_tb(exc_tb)
-                    }
+        filename = cause[0]
+        line = cause[1]
+        msg = traceback.format_exception_only(exc_type, exc_val)[0].replace('\n','; ')
 
-                    self.log.error(error, {'context':context})
+        error = 'file=%s line=%s msg="%s"' % (filename, line, msg)
+        context = {
+            'traceback': traceback.format_tb(exc_tb),
+            'method': request.method,
+            'path': request.path,
+            'meta': request.META
+        }
 
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except:
-            self.handleError(record)
+        self.log.error(error, {'context':context})

--- a/mysite/log_handlers.py
+++ b/mysite/log_handlers.py
@@ -1,4 +1,5 @@
-import logging, traceback, os, sys
+import logging, traceback, os, sys, json
+from mysite.helpers import is_json
 from logdna import LogDNAHandler as LogDNA
 
 class LogDNAMiddleware(object):
@@ -34,8 +35,11 @@ class LogDNAMiddleware(object):
         context = {
             'traceback': traceback.format_tb(exc_tb),
             'method': request.method,
-            'path': request.path,
-            'meta': request.META
+            'path': request.path
         }
+
+        for k,v in request.META.iteritems():
+            if isinstance(v, str):
+                context[k] = v;
 
         self.log.error(error, {'context':context})

--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -79,6 +79,8 @@ MIDDLEWARE = [
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+
+    'mysite.log_handlers.LogDNAMiddleware',
 ]
 
 ROOT_URLCONF = 'mysite.urls'

--- a/mysite/settings/production.py
+++ b/mysite/settings/production.py
@@ -65,28 +65,6 @@ POSTMARK_TRACK_OPENS = False
 DEFAULT_FROM_EMAIL = POSTMARK_SENDER
 SERVER_EMAIL = POSTMARK_SENDER
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse',
-        },
-    },
-    'handlers': {
-        'logdna': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'mysite.log_handlers.LogDNAHandler'
-        },
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['logdna'],
-        }
-    }
-}
-
 try:
     from .local import *
 except ImportError:

--- a/mysite/settings/production.py
+++ b/mysite/settings/production.py
@@ -65,6 +65,28 @@ POSTMARK_TRACK_OPENS = False
 DEFAULT_FROM_EMAIL = POSTMARK_SENDER
 SERVER_EMAIL = POSTMARK_SENDER
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+    },
+    'handlers': {
+        'logdna': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'mysite.log_handlers.LogDNAHandler'
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['logdna'],
+        }
+    }
+}
+
 try:
     from .local import *
 except ImportError:

--- a/mysite/settings/production.py
+++ b/mysite/settings/production.py
@@ -13,7 +13,7 @@ APPEND_SLASH = True
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 
-ADMINS = [('Kirk', 'jackson@newamerica.org'), ('Andrew', 'lomax@newamerica.org')]
+#ADMINS = [('Kirk', 'jackson@newamerica.org'), ('Andrew', 'lomax@newamerica.org')]
 
 # Will be changed to final host url
 ALLOWED_HOSTS = ['*']

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,3 +102,4 @@ Werkzeug==0.10.1
 whitenoise==3.0
 Willow==0.4
 Wand==0.4.4
+logdna==1.0.2


### PR DESCRIPTION
Error logging with [LogDNA API](https://github.com/logdna/python) addressing #1201

writes error like:
`Mar 1 10:31:09 <hostname> newamerica-cms [ERROR] file=<filepath> line=<lineno> msg="<message>"`

in LogDNA console, full traceback available in context object. 
can now add environment variable HOSTNAME to Heroku configs
