### PR TITLE
Add Datawrapper's responsive js to report template

### DIFF
--- a/report/templates/report/report.html
+++ b/report/templates/report/report.html
@@ -17,6 +17,7 @@
   {% if page.dataviz_src %}
     <script type="text/javascript" src="{{page.dataviz_src}}"></script>
   {% endif %}
+  <script type="text/javascript">!function(){"use strict";window.addEventListener("message",function(a){if(void 0!==a.data["datawrapper-height"])for(var e in a.data["datawrapper-height"]){var t=document.getElementById("datawrapper-chart-"+e)||document.querySelector("iframe[src*='"+e+"']");t&&(t.style.height=a.data["datawrapper-height"][e]+"px")}})}();</script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
React isn't playing nice with including the js in the html provided by the user.