### PR TITLE
Initial work on datawrapper tabs on funding page

### DIFF
--- a/newamericadotorg/assets/react/home-panels/pages/OurFunding.js
+++ b/newamericadotorg/assets/react/home-panels/pages/OurFunding.js
@@ -232,11 +232,11 @@ class OurFundingMain extends Component {
           </div>
           <div className="dataviz__chart-container">
             <Switch>
-              <Route exact path="/our-funding/" render={(props)=>(
-                <iframe title="Moore's Law: &quot;The transistor count doubles every two years.&quot;" aria-label="Table" id="datawrapper-chart-UOHEE" src="//datawrapper.dwcdn.net/UOHEE/1/" scrolling="no" frameborder="0" width="100%" height="600"></iframe>
-              )}/>
               <Route exact path="/our-funding/2018/" render={(props)=>(
                 <iframe title="European countries with the lowest &amp;amp; highest voter turnout" aria-label="Bar Chart" id="datawrapper-chart-vNnBJ" src="//datawrapper.dwcdn.net/vNnBJ/1/"  scrolling="no" frameborder="0" width="100%" height="650"></iframe>
+              )}/>
+              <Route render={(props)=>(
+                <iframe title="Moore's Law: &quot;The transistor count doubles every two years.&quot;" aria-label="Table" id="datawrapper-chart-UOHEE" src="//datawrapper.dwcdn.net/UOHEE/1/" scrolling="no" frameborder="0" width="100%" height="600"></iframe>
               )}/>
             </Switch>
       		</div>
@@ -261,7 +261,6 @@ export default class OurFunding extends Component {
       <div className="home__panels__content">
         <Nav />
         <Switch>
-          <Route exact path={["/our-funding/", "/our-funding/2018/"]} render={(props)=>( <OurFundingMain data={results.data} dataScript={results.data_project_external_script}/> )}/>
           <Route exact path="/our-funding/our-funders/" render={(props)=>( <OurFunderLists data={this.findSubpage('our-funders').data} heading={this.findSubpage('our-funders').title}/> )}/>
           <Route exact path="/our-funding/corporate-circle/" render={(props)=>( <FunderLists data={this.findSubpage('corporate-circle').data} /> )}/>
           <Route exact path="/our-funding/new-america-councils/" render={(props)=>( <Councils data={this.findSubpage('new-america-councils').data} /> )}/>
@@ -277,6 +276,7 @@ export default class OurFunding extends Component {
               </div>
             </div>
           )}/>
+          <Route render={(props)=>( <OurFundingMain data={results.data} dataScript={results.data_project_external_script}/> )}/>
         </Switch>
       </div>
     );

--- a/newamericadotorg/assets/react/home-panels/pages/OurFunding.js
+++ b/newamericadotorg/assets/react/home-panels/pages/OurFunding.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import ImageAside from '../components/ImageAside';
 import Reel from '../components/Reel';
 import Body from '../components/Body';
-import { Route, NavLink } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import HorizontalNav from '../../components/HorizontalNav';
 
 class FunderList extends Component {
@@ -223,9 +223,22 @@ class OurFundingMain extends Component {
         </div>}/>
         <div className="funding-table container--1080">
           <h1>{transparency_table.heading[0]}</h1>
-          <h3>{transparency_table.dataviz[0].title}</h3>
+          {/* <h3>{transparency_table.dataviz[0].title}</h3> */}
+          <div className={`container--1080 margin-top-15`}>
+            <HorizontalNav className={`our-funding__nav`} items={[
+              { url: '/our-funding/', label: '2019', exact: true },
+              { url: '/our-funding/2018/', label: '2018'},
+            ]} />
+          </div>
           <div className="dataviz__chart-container">
-      			<div className="dataviz__chart-area" id={transparency_table.dataviz[0].container_id}></div>
+            <Switch>
+              <Route exact path="/our-funding/" render={(props)=>(
+                <iframe title="Moore's Law: &quot;The transistor count doubles every two years.&quot;" aria-label="Table" id="datawrapper-chart-UOHEE" src="//datawrapper.dwcdn.net/UOHEE/1/" scrolling="no" frameborder="0" width="100%" height="600"></iframe>
+              )}/>
+              <Route exact path="/our-funding/2018/" render={(props)=>(
+                <iframe title="European countries with the lowest &amp;amp; highest voter turnout" aria-label="Bar Chart" id="datawrapper-chart-vNnBJ" src="//datawrapper.dwcdn.net/vNnBJ/1/"  scrolling="no" frameborder="0" width="100%" height="650"></iframe>
+              )}/>
+            </Switch>
       		</div>
           <div className="margin-top-35 margin-bottom-60" dangerouslySetInnerHTML={{__html: transparency_table.paragraph[0] }} />
         </div>
@@ -247,22 +260,24 @@ export default class OurFunding extends Component {
     return (
       <div className="home__panels__content">
         <Nav />
-        <Route path="/our-funding/" exact render={(props)=>( <OurFundingMain data={results.data} dataScript={results.data_project_external_script}/> )}/>
-        <Route path="/our-funding/our-funders/" render={(props)=>( <OurFunderLists data={this.findSubpage('our-funders').data} heading={this.findSubpage('our-funders').title}/> )}/>
-        <Route path="/our-funding/corporate-circle/" render={(props)=>( <FunderLists data={this.findSubpage('corporate-circle').data} /> )}/>
-        <Route path="/our-funding/new-america-councils/" render={(props)=>( <Councils data={this.findSubpage('new-america-councils').data} /> )}/>
-        <Route path="/our-funding/donate/" exact render={(props)=>(
-          <div className="container--1080 margin-80">
-            <div className="row gutter-20">
-              <article className="col-md-7 post-body home__panel__body__text">
-              <div className="margin-bottom-35">
-                <a className="button" href={donate.data.donate.button[0].button_link}>{donate.data.donate.button[0].button_text}</a>
+        <Switch>
+          <Route exact path={["/our-funding/", "/our-funding/2018/"]} render={(props)=>( <OurFundingMain data={results.data} dataScript={results.data_project_external_script}/> )}/>
+          <Route exact path="/our-funding/our-funders/" render={(props)=>( <OurFunderLists data={this.findSubpage('our-funders').data} heading={this.findSubpage('our-funders').title}/> )}/>
+          <Route exact path="/our-funding/corporate-circle/" render={(props)=>( <FunderLists data={this.findSubpage('corporate-circle').data} /> )}/>
+          <Route exact path="/our-funding/new-america-councils/" render={(props)=>( <Councils data={this.findSubpage('new-america-councils').data} /> )}/>
+          <Route exact path="/our-funding/donate/" render={(props)=>(
+            <div className="container--1080 margin-80">
+              <div className="row gutter-20">
+                <article className="col-md-7 post-body home__panel__body__text">
+                <div className="margin-bottom-35">
+                  <a className="button" href={donate.data.donate.button[0].button_link}>{donate.data.donate.button[0].button_text}</a>
+                </div>
+                <div dangerouslySetInnerHTML={{__html: donate.data.donate.paragraph[0] }} />
+                </article>
               </div>
-              <div dangerouslySetInnerHTML={{__html: donate.data.donate.paragraph[0] }} />
-              </article>
             </div>
-          </div>
-        )}/>
+          )}/>
+        </Switch>
       </div>
     );
   }


### PR DESCRIPTION
@kevinhowbrook Can you take a look at this? I'm having trouble figuring out how to make it so that going directly to http://localhost:8000/our-funding/2018 doesn't 404. React-router doesn't seem to like to do hashes unless you're using the hash router, and I didn't find where we're telling Django that the urls like our-funding/our-funders should be handled by react.

To see my changes, go to  http://localhost:8000/our-funding/ and see the datawrapper embed (currently just example things) as well as the nav to switch between the 2019 and 2018 table (or, right now, the table about moore's law and the chart about voting).

Note that the datawrapper embeds don't have responsive height because the JS for that is on the other branch (see #1385). 

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/1051450/60365707-7e631b80-99b7-11e9-814c-eb2196d288b8.png">



Changes:
- Use Datawrapper chart instead of custom chart
- Use existing tab setup to allow multiple charts
- Currently the url /our-funding/2018 will 404 if you refresh it, because Django then handles it
