### PR TITLE
Merge `staging` (with `1399-tweak-og-image-size`) into `master`

### DIFF
--- a/newamericadotorg/templates/base.html
+++ b/newamericadotorg/templates/base.html
@@ -34,8 +34,9 @@
   <meta name="twitter:description" content="{% firstof page.search_description page.story_excerpt %}" />
 
   {% if page.story_image %}
-    <meta property="og:image" content='https://s3.amazonaws.com/newamericadotorg/{{ page.story_image.file.name }}' />
-    <meta name="twitter:image" content='https://s3.amazonaws.com/newamericadotorg/{{ page.story_image.file.name }}' />
+    {% image page.story_image fill-1200x630 as og_image %}
+    <meta property="og:image" content='https://s3.amazonaws.com/newamericadotorg/{{ og_image.file.name }}' />
+    <meta name="twitter:image" content='https://s3.amazonaws.com/newamericadotorg/{{ og_image.file.name }}' />
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@NewAmerica">
   {% endif %}


### PR DESCRIPTION
This wasn't testable with https://developers.facebook.com/tools/debug/og/object because all pages have the og:url set to the equivalent production url, but it does do what it is intended to do, so I'm merging it. I won't mark #1399  as closed until it's tested on production with a large image, though.