### PR TITLE
Download only original images

### DIFF
--- a/home/management/commands/downloadlocalimages.py
+++ b/home/management/commands/downloadlocalimages.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
 
             for r in i.renditions.all():
                 try:
-                    print('downloading ' + r.file.name + '...')
-                    s3.Bucket(BUCKET_NAME).download_file(r.file.name, 'media/' + r.file.name)
+                    print('deleting rendition ' + r.file.name + '...')
+                    r.delete()
                 except botocore.exceptions.ClientError as e:
                     print('The object: ' + r.file.name + ' does not exist')


### PR DESCRIPTION
Considering that `original_images` is 14+ GB and `images` is 9+ GB, it doesn't seem worth it to me to have the `downloadlocalimages` command download both.

I've made a minimal change to delete renditions of each image instead of downloading them. I would be interested to know if there's a better or more elegant way to do this, or if there's a reason it's not the best plan! I know this is a pretty trivial thing to change, but I think every time I touch Python is a good time for me to learn more about best practices.

Some questions:
- Should I also remove this line? It doesn't seem necessary since we're not putting anything there now.
  ```os.makedirs('media/images', exist_ok=True)```
- Would it make sense to just remove the print statements about deleting the renditions?
- Is the try/except for the renditions moot now?
- Is there a more efficient way to delete the renditions? I found that @gasman suggested [here](https://stackoverflow.com/a/42373300) that someone run `DELETE FROM wagtailimages_rendition;` but that did not work for me (and I'm not sure whether it could be done from within this command).