### PR TITLE
[WAITING] Add redirect from bretton-woods-ii to digi

### DIFF
--- a/newamericadotorg/redirects.py
+++ b/newamericadotorg/redirects.py
@@ -10,3 +10,9 @@ def dual_language_learners(request, **kwargs):
     path[2] = 'english-learners'
     url = '/'.join(path)
     return redirect(url)
+
+def digi(request, **kwargs):
+    path = request.path.split('/')
+    path[1] = 'digi'
+    url = '/'.join(path)
+    return redirect(url)

--- a/newamericadotorg/urls.py
+++ b/newamericadotorg/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
 
     url(r'^international-security/future-property-rights/[^.]*$', redirects.future_property_rights),
     url(r'^education-policy/dual-language-learners/[^.]*$', redirects.dual_language_learners),
+    url(r'^bretton-woods-ii/[^.]*$', redirects.digi),
 
     url(r'^(?P<program>[a-zA-z\-]*)/reports/(?P<report_name>[a-zA-Z0-9_\.\-]*)/pdf/$', report_views.pdf),
     url(r'^(?P<program>[a-zA-z\-]*)/reports/(?P<report_name>[a-zA-Z0-9_\.\-]*)/pdf/render/$', report_views.pdf_render),


### PR DESCRIPTION
Fixes #1422 

Modeled off of https://github.com/newamericafoundation/newamerica-cms/commit/4fb6f34df2f5fca6346d0b55983da33c5239dfce

This solves a problem where links like https://staging.newamerica.org/bretton-woods-ii/blockchain-trust-accelerator/reports/blockchain-impact-ledger/blockchain-impact-ledger/ are unaffected by Karl's redirect solution (#1440). I noted in #1416 that the program name doesn't matter at all in the url for sections of reports... and redirects from those urls appear to do nothing at all, I assume because of the order in which things are in charge of routing. 

This is inelegant but I suspect it is the correct solution for tomorrow. Thoughts, @kaedroho? Thoughts on whether we should do this in concert with your solution or on its own? The downside of doing only this option is that we have to time it with the page slug change. It occurs to me that if we do both of them we would do your solution and then deploy the urls change, which would avoid timing problems related to changing the program page at the same time as deployment. On the other side, having a whole pile of redirects that we don't need seems cluttery, though I don't know whether that's a downside worth considering especially when we already have so many redirects that what does adding another hundred or two matter.