### PR TITLE
[1459] Disable browser API cache

### DIFF
--- a/newamericadotorg/assets/react/feedback/index.js
+++ b/newamericadotorg/assets/react/feedback/index.js
@@ -7,7 +7,6 @@ import { SET_FEEDBACK, SET_FEEDBACK_TYPE, SET_FEEDBACK_MESSAGE, SET_FEEDBACK_LEV
 import { Text, TextArea } from '../components/Inputs';
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
-import cache from '../cache';
 import { PlusX } from '../components/Icons';
 import * as REDUCERS from './reducers';
 

--- a/newamericadotorg/assets/react/feedback/reducers.js
+++ b/newamericadotorg/assets/react/feedback/reducers.js
@@ -1,5 +1,4 @@
 import { SET_FEEDBACK, SET_FEEDBACK_TYPE, SET_FEEDBACK_MESSAGE, SET_FEEDBACK_LEVEL, SET_FEEDBACK_EMAIL, RESET_FEEDBACK } from './constants';
-import cache from '../cache';
 import bowser from 'bowser';
 
 const _browser = bowser.getParser(window.navigator.userAgent);

--- a/newamericadotorg/assets/react/react-renderer.js
+++ b/newamericadotorg/assets/react/react-renderer.js
@@ -4,7 +4,6 @@ import { camelize, getProps } from '../lib/utils/index';
 import React from 'react';
 import { siteReducer } from './reducers';
 import store from './store';
-import cache from './cache';
 
 class ReactRenderer {
   constructor(store){

--- a/newamericadotorg/assets/react/setMeta.js
+++ b/newamericadotorg/assets/react/setMeta.js
@@ -1,18 +1,8 @@
 import store from './store';
-import cache from './cache';
 import { fetchData, setParams } from './api/actions';
 
 const setMeta = () => {
   store.dispatch(setParams('meta', { endpoint: 'meta' } ));
-  cache.set('/api/meta/',
-    {
-      count: 0,
-      hasNext: false,
-      hasPrevious: false,
-      page: 1,
-      results: window.meta
-    }
-  );
   store.dispatch(fetchData('meta'));
 }
 


### PR DESCRIPTION
This removes the browser-side caching of API responses.

It's been causing issues in the publications index and program pages, we don't think this cache provides much performance benefit and removing it solves these issues and simplifies the code a bit.