### PR TITLE
Use BEM for card types

### DIFF
--- a/newamericadotorg/assets/react/components/ContentCards.js
+++ b/newamericadotorg/assets/react/components/ContentCards.js
@@ -109,7 +109,7 @@ const generateAuthors = authors => {
 export const PublicationListItem = ({ post }) => (
   <div
     className={`card list ${
-      post.content_type ? post.content_type.api_name : ''
+      post.content_type ? `card--${post.content_type.api_name}` : ''
     }`}
   >
     <a href={post.url}>

--- a/newamericadotorg/assets/scss/components/card/_list.scss
+++ b/newamericadotorg/assets/scss/components/card/_list.scss
@@ -48,7 +48,7 @@
     }
   }
 
-  &.book img {
+  &.card--book img {
     height: 100%;
   }
 


### PR DESCRIPTION
`.card.list.program` was getting styles for `.program` that it was not supposed to be getting.

e.g. the card for education policy here: https://staging.newamerica.org/search/?query=education+policy