### PR TITLE
Add na-develop.herokuapp.com to ALLOWED_HOSTS

### DIFF
--- a/newamericadotorg/settings/production.py
+++ b/newamericadotorg/settings/production.py
@@ -18,7 +18,8 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # Will be changed to final host url
 ALLOWED_HOSTS = [
     '.newamerica.org',
-    'na-staging.herokuapp.com'
+    'na-staging.herokuapp.com',
+    'na-develop.herokuapp.com',
 ]
 
 SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
Does this make sense just to put on `master` in this manner? Are there other things on `develop` that aren't on `wagtail-update` (since anything on `develop` that's different from `master` should be from `wagtail-update`? 

Also do we still need the `wagtail-update-staging` branch?