### PR TITLE
Use absolute URL for timeline.js

### DIFF
--- a/newamericadotorg/templates/blocks/timeline.html
+++ b/newamericadotorg/templates/blocks/timeline.html
@@ -64,4 +64,4 @@
 
 </div>
 
-<script async src="{% static 'js/timeline.js' %}"></script>
+<script async src="https://d3fvh0lm0eshry.cloudfront.net/static/js/timeline.js"></script>


### PR DESCRIPTION
This file isn't checked in to the repo, it must've been added to the S3 bucket manually.

This is causing a crash because Django can't see this file. (see https://www.newamerica.org/in-depth/malware-markets/what-are-malware-markets/)