### PR TITLE
[1527] Remove custom exception handling

### DIFF
--- a/newamericadotorg/log_handlers.py
+++ b/newamericadotorg/log_handlers.py
@@ -9,8 +9,10 @@ class LoggerFilter(logging.Filter):
     def filter(self, record):
         print(record.getMessage())
 
+
 logger = logging.getLogger('weasyprint')
 logger.addFilter(LoggerFilter())
+
 
 class APIExceptionMiddleware:
     def __init__(self, get_response):
@@ -33,8 +35,6 @@ class APIExceptionMiddleware:
             msg = traceback.format_exception_only(exc_type, exc_val)[0].replace('\n','; ')
 
             error_source = 'file=%s line=%s' % (filename, line)
-            logdna = LogDNAMiddleware(self.get_response)
-            logdna.process_exception(request, exception)
             return JsonResponse({
                 'count': None,
                 'next': None,
@@ -45,44 +45,3 @@ class APIExceptionMiddleware:
                 'message': msg
             })
 
-class LogDNAMiddleware(object):
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-        API_KEY = os.getenv('LOGDNA_KEY')
-        handler = LogDNA(API_KEY,{
-            'index_meta': True,
-            'app': 'newamerica-cms',
-            'level': 'Error',
-            'hostname': os.getenv('HOSTNAME') or 'na-errors'
-        })
-        self.log = logging.getLogger('logdna')
-        self.log.addHandler(handler)
-
-    def __call__(self, request):
-        response = self.get_response(request)
-        return response
-
-    def process_exception(self, request, exception):
-        exc_info = sys.exc_info()
-
-        exc_type, exc_val, exc_tb = exc_info
-        tb = traceback.extract_tb(exc_tb)
-        cause = tb[len(tb)-1]
-
-        filename = cause[0]
-        line = cause[1]
-        msg = traceback.format_exception_only(exc_type, exc_val)[0].replace('\n','; ')
-
-        error = 'file=%s line=%s msg="%s"' % (filename, line, msg)
-        context = {
-            'traceback': traceback.format_tb(exc_tb),
-            'method': request.method,
-            'path': request.path
-        }
-
-        for k,v in request.META.items():
-            if isinstance(v, str):
-                context[k] = v;
-
-        self.log.error(error, {'context':context})

--- a/newamericadotorg/log_handlers.py
+++ b/newamericadotorg/log_handlers.py
@@ -1,8 +1,4 @@
-import logging, traceback, os, sys, json
-from newamericadotorg.helpers import is_json
-from logdna import LogDNAHandler as LogDNA
-from django.http import JsonResponse
-from django.conf import settings
+import logging
 
 
 class LoggerFilter(logging.Filter):
@@ -11,37 +7,4 @@ class LoggerFilter(logging.Filter):
 
 
 logger = logging.getLogger('weasyprint')
-logger.addFilter(LoggerFilter())
-
-
-class APIExceptionMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-        return response
-
-    def process_exception(self, request, exception):
-        if 'api' in request.path and not settings.DEBUG:
-            exc_info = sys.exc_info()
-
-            exc_type, exc_val, exc_tb = exc_info
-            tb = traceback.extract_tb(exc_tb)
-            cause = tb[len(tb)-1]
-
-            filename = cause[0]
-            line = cause[1]
-            msg = traceback.format_exception_only(exc_type, exc_val)[0].replace('\n','; ')
-
-            error_source = 'file=%s line=%s' % (filename, line)
-            return JsonResponse({
-                'count': None,
-                'next': None,
-                'previous': None,
-                'results': [],
-                'error': True,
-                'error_source': error_source,
-                'message': msg
-            })
-
+    .addFilter(LoggerFilter())

--- a/newamericadotorg/settings/production.py
+++ b/newamericadotorg/settings/production.py
@@ -13,10 +13,6 @@ APPEND_SLASH = True
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 
-MIDDLEWARE += [
-    'newamericadotorg.log_handlers.APIExceptionMiddleware'
-]
-
 #ADMINS = [('Kirk', 'jackson@newamerica.org'), ('Andrew', 'lomax@newamerica.org')]
 
 # Will be changed to final host url

--- a/newamericadotorg/settings/production.py
+++ b/newamericadotorg/settings/production.py
@@ -14,7 +14,6 @@ APPEND_SLASH = True
 SECRET_KEY = os.getenv("SECRET_KEY")
 
 MIDDLEWARE += [
-    'newamericadotorg.log_handlers.LogDNAMiddleware',
     'newamericadotorg.log_handlers.APIExceptionMiddleware'
 ]
 


### PR DESCRIPTION
https://github.com/newamericafoundation/newamerica-cms/issues/1527

The existing exception handling was logging all exceptions (including both 5xx and 4xx errors) to LogDNA.

We now have Sentry for error management and these errors are also being sent there. Sentry already catches exceptions itself in a way that formats the errors better and also filters out errors we don't care about like 404s.

Also, errors raised from the API were being converted into 200 responses even though the client-side seems to have code that handles errors.

This PR removes both of these behaviours. Now errors are only logged to Sentry and this is done in a more standard way.