### PR TITLE
Add redirect for New Practice Lab

### DIFF
--- a/newamericadotorg/redirects.py
+++ b/newamericadotorg/redirects.py
@@ -1,9 +1,20 @@
 from django.shortcuts import render, redirect
 
+
+# Subprograms changing to programs
+
 def future_property_rights(request, **kwargs):
     path = request.path.split('/')[3:]
     url = '/future-property-rights/' + '/'.join(path)
     return redirect(url)
+
+def new_practice_lab(request, **kwargs):
+    path = request.path.split('/')[3:]
+    url = '/new-practice-lab/' + '/'.join(path)
+    return redirect(url)
+
+
+# Name changes
 
 def dual_language_learners(request, **kwargs):
     path = request.path.split('/')

--- a/newamericadotorg/urls.py
+++ b/newamericadotorg/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
     url(r'^bretton-woods-ii/[^.]*$', redirects.digi),
     url(r'^digital-impact-governance-inititiative/[^.]*$', redirects.digi),
     url(r'^national-network/[^.]*$', redirects.local),
+    url(r'^public-interest-technology/new-practice-lab/[^.]*$', redirects.new_practice_lab),
 
     url(r'^(?P<program>[a-zA-z\-]*)/(?P<subprogram>[a-zA-Z0-9_\.\-]*)/(our-people|events|projects|publications|topics|about|subscribe)/$', program_views.redirect_to_subprogram),
     url(r'^(?P<program>[a-zA-z\-]*)/(our-people|events|projects|about|publications|topics|subscribe)/$', program_views.redirect_to_program),


### PR DESCRIPTION
Goal is to redirect from https://www.newamerica.org/public-interest-technology/new-practice-lab/
to  https://www.newamerica.org/new-practice-lab including all the children of those pages

this redirect works exactly the same as the future of property rights one 
(yes maybe we should eventually make a less clunky way to do this but not today)