### PR TITLE
Remove 'About Page' text from program simple pages

### DIFF
--- a/newamericadotorg/templates/components/post_heading_text.html
+++ b/newamericadotorg/templates/components/post_heading_text.html
@@ -6,7 +6,7 @@
   {% if page.subheading %}
     <h6 class="subheading">{{ page.subheading }}</h6>
   {% endif %}
-  {% if page|model_name != 'home.OrgSimplePage' %}
+  {% if page|model_name != 'home.OrgSimplePage' and page|model_name != 'home.ProgramSimplePage' %}
     <h5>{% firstof page.other_content_type.singular_title page|model_display_name %}{% if page.source %} in {{ page.source }}{% endif %}</h5>
   {% endif %}
   {% if page.source %}


### PR DESCRIPTION
Closes #1540 (unless there are other pages where this is happening and i missed them)

Easy to test at http://localhost:8000/asset-building/millennials-rising/about-millennials-rising/

Old | New
---|---
<img width="722" alt="image" src="https://user-images.githubusercontent.com/1051450/90787689-fe8ec380-e2d2-11ea-84aa-d94233b951e2.png"> | <img width="716" alt="image" src="https://user-images.githubusercontent.com/1051450/90787669-f9317900-e2d2-11ea-9dde-159196ed9992.png">
