### PR TITLE
Exclude periods adjacent to HTML tags from endnote URLs

### DIFF
--- a/newamericadotorg/assets/react/report/components/EndnoteAside.js
+++ b/newamericadotorg/assets/react/report/components/EndnoteAside.js
@@ -8,7 +8,7 @@ class Endnote extends Component {
     let {
       endnote: { note }
     } = this.props;
-    let r = /(http.+?)(\.\s|;|$|<|\.$| |,)/g;
+    let r = /(http.+?)(\.\s|;|$|<|\.<|\.$| |,)/g;
     const text = note.replace(r, (match, p1, p2) => {
       return `<a href="${p1}">source</a>${p2}`;
     });


### PR DESCRIPTION
Slightly updates URL-detection regular expression in endnotes to account for periods next to HTML tags.

Fixes #1413 

### Further notes

Sometimes endnotes contain URLs, punctuation, and HTML content that run up against each other in a way resembling:

```
<p>text http://www.example.com.</p>
```

In our current regex-based URL detection scheme, the `.` character would be included in the above URL.  We have a list of possible character sequences that terminate a URL, and I've added `\.<` (a literal period followed by an open pointy-bracket) to this list, which lets us correctly exclude the period from the URL in situations like the above.

It's possible that our list of exclusions will eventually get unwieldy, but URL-finding in general is kind of hard and adding one more right now seems like the least intrusive solution.

