### PR TITLE
Remove option to copy pages

### DIFF
--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -1,11 +1,19 @@
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html, format_html_join
 from django.conf import settings
+from django.http import HttpResponseForbidden
 
 from wagtail.admin.rich_text.editors.draftail import features as draftail_features
 from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler, BlockElementHandler
 from wagtail.core import hooks
 from wagtail.core.whitelist import attribute_rule, check_url, allow_without_attributes
+
+
+@hooks.register('before_copy_page')
+def before_copy_page(request, page):
+    # Permit copying pages only for superusers
+    if not request.user.is_superuser:
+        return HttpResponseForbidden()
 
 
 @hooks.register('construct_whitelister_element_rules')

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -15,7 +15,9 @@ def remove_copy_button_for_non_superusers(buttons, page, page_perms, is_parent=F
         for top_button in buttons:
             if hasattr(top_button, 'dropdown_buttons'):
                 top_button.dropdown_buttons = [
-                    b for b in top_button.dropdown_buttons if b.label != 'Copy'
+                    # 20 = the priority value of the "Copy" button, as
+                    # defined in wagtail
+                    b for b in top_button.dropdown_buttons if b.priority != 20
                 ]
 
 

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -9,6 +9,16 @@ from wagtail.core import hooks
 from wagtail.core.whitelist import attribute_rule, check_url, allow_without_attributes
 
 
+@hooks.register('construct_page_listing_buttons')
+def remove_copy_button_for_non_superusers(buttons, page, page_perms, is_parent=False, context=None):
+    if not page_perms.user.is_superuser:
+        for top_button in buttons:
+            if hasattr(top_button, 'dropdown_buttons'):
+                top_button.dropdown_buttons = [
+                    b for b in top_button.dropdown_buttons if b.label != 'Copy'
+                ]
+
+
 @hooks.register('before_copy_page')
 def before_copy_page(request, page):
     # Permit copying pages only for superusers


### PR DESCRIPTION
Fixes #1395

This change has two effects:

1. Removes the "Copy" option from the "More" dropdown menus on the page listing for everyone except superusers.

2. Installs a hook that rejects page copy actions from anyone except superusers. This fully prevents anyone in the disallowed group from copying a page, even by means other than now-removed Copy option.