### PR TITLE
Update wagtail from 2.8 to 2.10

### DIFF
--- a/home/templatetags/top_menu.py
+++ b/home/templatetags/top_menu.py
@@ -1,6 +1,7 @@
 from datetime import date
 from django import template
 from django.conf import settings
+from wagtail.core.models import Site
 
 from programs.models import Program
 
@@ -10,7 +11,7 @@ register = template.Library()
 def get_site_root(context):
     # NB this returns a core.Page, not the implementation-specific model used
     # so object-comparison to self will return false as objects would differ
-    return context['request'].site.root_page
+    return Site.find_for_request(context['request']).root_page
 
 
 def has_menu_children(page):

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'wagtail.images',
     'wagtail.search',
     'wagtail.admin',
+    'wagtail.contrib.legacy.richtext',
     'wagtail.core',
     'wagtail.contrib.styleguide',
     'wagtail.contrib.table_block',
@@ -89,7 +90,6 @@ MIDDLEWARE = [
 
     'whitenoise.middleware.WhiteNoiseMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     # Gzip/minify

--- a/report/tasks.py
+++ b/report/tasks.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from weasyprint import HTML
 from django.template import loader
 import tempfile
-from wagtail.documents.models import get_document_model
+from wagtail.documents import get_document_model
 from newamericadotorg.celery import app as celery_app
 from django.apps import apps
 from wagtail.core.models import PageRevision

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.0.3
-Wagtail==2.8.1
+Wagtail==2.10
 
 # Packages that depend on Django version
 Celery==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.0.3
-Wagtail==2.10
+Wagtail==2.10.1
 
 # Packages that depend on Django version
 Celery==4.4.0


### PR DESCRIPTION
Fixes #1531 

## Summary of changes

In 2.9, `SiteMiddleware` was deprecated.  We weren't using `request.site` anywhere, so I removed the middleware itself as it's not needed.

In 2.10:

1. `get_document_model` import path changed
2. `<div class="rich-text">` wrappers removed from rich text.  Because we are using `.rich-text` selectors in our CSS, I've chosen to maintain the old behavior by adding a line to `INSTALLED_APPS`.  In the future we may want to change this, but I think that would require a more extensive review of rich text rendering across all the site content than I am capable of giving right now.

See this link for more information:

https://docs.wagtail.io/en/stable/reference/contrib/legacy_richtext.html#legacy-richtext

## Other considerations

In 2.10, the [workflow for moderation](https://docs.wagtail.io/en/stable/releases/2.10.html#move-to-new-configurable-moderation-system-workflow) seems to have changed substantially. It may be worth considering if these changes are applicable to users of our site, and what adaptations may have to be made.

Also, 2.10 drops support for python 3.5. We are using 3.6, which is also getting somewhat old. It may be worth considering upgrading to python 3.7 or 3.8 in the near future.