### PR TITLE
Add fabric task to copy heroku production data to staging

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -74,6 +74,16 @@ def pull_staging_images(c):
     pull_images_from_s3_heroku(c, STAGING_APP_INSTANCE)
 
 
+@task
+def sync_staging_from_production(c):
+    """Copy database from production to staging"""
+    copy_heroku_database(
+        c,
+        destination=STAGING_APP_INSTANCE,
+        source=PRODUCTION_APP_INSTANCE,
+    )
+
+
 #######
 # Local
 #######
@@ -143,6 +153,17 @@ def open_heroku_shell(c, app_instance, shell_command="bash"):
     local(
         "heroku run --app {app} {command}".format(
             app=app_instance, command=shell_command
+        )
+    )
+
+
+# The single star (*) below indicates that all the arguments
+# afterwards must be given as keywords.  See PEP 3102 to learn more.
+def copy_heroku_database(c, *, source, destination):
+    check_if_logged_in_to_heroku(c)
+    local(
+        "heroku pg:copy {source_app}::DATABASE_URL DATABASE_URL --app {destination_app}".format(
+            source_app=source, destination_app=destination
         )
     )
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -82,6 +82,11 @@ def sync_staging_from_production(c):
         destination=STAGING_APP_INSTANCE,
         source=PRODUCTION_APP_INSTANCE,
     )
+    sync_heroku_buckets(
+        c,
+        destination=STAGING_APP_INSTANCE,
+        source=PRODUCTION_APP_INSTANCE,
+    )
 
 
 #######
@@ -166,6 +171,29 @@ def copy_heroku_database(c, *, source, destination):
             source_app=source, destination_app=destination
         )
     )
+
+
+# The single star (*) below indicates that all the arguments
+# afterwards must be given as keywords.  See PEP 3102 to learn more.
+def sync_heroku_buckets(c, *, source, destination):
+    destination_bucket_name = get_heroku_variable(
+        c, destination, "S3_BUCKET_NAME"
+    )
+    destination_access_key_id = get_heroku_variable(c, destination, "AWS_ACCESS_KEY_ID")
+    destination_secret_access_key = get_heroku_variable(
+        c, destination, "AWS_SECRET_ACCESS_KEY"
+    )
+
+    source_bucket_name = get_heroku_variable(
+        c, source, "S3_BUCKET_NAME"
+    )
+
+    aws_cmd = "s3 sync --delete s3://{source_bucket_name} s3://{destination_bucket_name}".format(
+        source_bucket_name=source_bucket_name, destination_bucket_name=destination_bucket_name
+    )
+
+    aws(c, aws_cmd, destination_access_key_id, destination_secret_access_key)
+
 
 
 ####


### PR DESCRIPTION
This pull request adds a fabric task `sync-staging-from-production` which runs the [`heroku pg:copy`](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-pg-copy-source-target) command to copy the entire database from the production app into the staging app.

Fixes #1401 

### Notes

* The `fab sync-staging-from-production` command currently requires a user confirmation. I think this is all right if we mostly intend this command to be run by people, given that it is a destructive operation and it might be best to avoid accidentally overwriting data. However, if we want to automate this command, it might be best to alter the command to not require that confirmation step.

* At a technical level, the function `copy_heroku_database` uses required/enforced keyword arguments because I worry about the consequences of accidentally switching the `source` and `destination` arguments if they're supplied positionally. It's a slightly obscure feature though, and maybe the codebase doesn't need it. I suppose another option is to hard-code this copy operation. Either way, feedback on this is welcome and I'm fine to change it to something else.