### PR TITLE
Post API performance pass

### DIFF
--- a/newamericadotorg/api/helpers.py
+++ b/newamericadotorg/api/helpers.py
@@ -28,7 +28,7 @@ def generate_image_rendition(image, filter_spec=None):
 
 
 def get_content_type(obj):
-    content_type = obj.get_ancestors().type(AbstractContentPage).first()
+    content_type = obj.get_ancestors().type(AbstractContentPage).select_related('content_type').first()
     if content_type:
         content_type = content_type.specific
         name = getattr(content_type, 'singular_title', None)

--- a/newamericadotorg/api/post/serializers.py
+++ b/newamericadotorg/api/post/serializers.py
@@ -62,8 +62,8 @@ class PostSerializer(ModelSerializer):
         return PostSubprogramSerializer(obj.post_subprogram, many=True).data
 
     def get_authors(self, obj):
-        authors_rel = obj.authors.order_by('pk')
-        if authors_rel is None:
+        authors_rel = obj.authors.all()
+        if not authors_rel:
             return None
         authors = [rel.author for rel in authors_rel]
         return AuthorSerializer(authors, many=True, context=self.context).data


### PR DESCRIPTION
Refs #1533

This makes a first pass at improving performance via reducing the
number of database queries made by requests to the Posts API.  Much of
what's being changed here is "low-hanging fruit" in the form of
applying `prefetch_related` and `select_related` to our initial query
to prevent further queries later.

In my local testing, this definitely reduced the number of queries
performed, and I'd be interested in seeing what the performance looks
like in the production environment before working too much more on
further improving the performance.

I'll note that one big source of additional queries is the
`get_content_type` function.  Some of these queries, particularly ones
related to finding a page's wagtail-ancestor and its specific page
type, I am not sure exactly how to prefetch or if they can be (though
it may very well be possible).