### PR TITLE
Fix missing Draftail icons for Blockquote and Pullquote features

### DIFF
--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -97,7 +97,7 @@ def register_pullquote_feature(features):
 
     control = {
         'type': type_,
-        'icon': 'icon icon-openquote',
+        'icon': 'openquote',
         'description': 'Pullquote',
         'element': 'blockquote'
     }
@@ -134,7 +134,7 @@ def register_blockquote_feature(features):
 
     control = {
         'type': type_,
-        'icon': 'icon icon-arrow-right',
+        'icon': 'arrow-right',
         'description': 'Blockquote',
         'element': 'blockquote',
     }


### PR DESCRIPTION
Icons needed to use new SVG format rather than icon font, which just required removing the `icon icon-` prefix.