### PR TITLE
Update modelcluster to 5.1 to fix all posts appearing to have the same author

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-storages==1.9.1
 django-compressor==2.4
 django-anymail==7.0.0
 django-filter==2.2.0
+django-modelcluster==5.1
 logdna==1.5.3
 whitenoise==5.0.1
 django-redis==4.11.0


### PR DESCRIPTION
This turned out to be a result of the bug which was fixed by https://github.com/wagtail/django-modelcluster/pull/130 which caused prefetching with lookup fields to work incorrectly due to modelcluster not returning a copy of the queryset when applying filters, coupled with the recent post API performance pass that added a prefetch to this field. Updating to 5.1 fixes this locally.