### PR TITLE
Improve production-to-staging sync

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -3,7 +3,7 @@ from invoke.exceptions import Exit
 from invoke.tasks import task
 
 PRODUCTION_APP_INSTANCE = "newamericadotorg"
-STAGING_APP_INSTANCE = "na-staging"
+STAGING_APP_INSTANCE = "na-develop"
 
 LOCAL_MEDIA_FOLDER = "/vagrant/media"
 LOCAL_IMAGES_FOLDER = "/vagrant/media/original_images"
@@ -173,7 +173,7 @@ def open_heroku_shell(c, app_instance, shell_command="bash"):
 def copy_heroku_database(c, *, source, destination):
     check_if_logged_in_to_heroku(c)
     local(
-        "heroku pg:copy {source_app}::DATABASE_URL DATABASE_URL --app {destination_app}".format(
+        "heroku pg:copy {source_app}::DATABASE_URL DATABASE_URL --app {destination_app} --confirm {destination_app}".format(
             source_app=source, destination_app=destination
         )
     )
@@ -216,7 +216,6 @@ def sync_heroku_buckets(c, *, source, destination, folders=[]):
             folder='',
         )
         aws(c, aws_cmd, destination_access_key_id, destination_secret_access_key)
-
 
 ####
 # S3

--- a/fabfile.py
+++ b/fabfile.py
@@ -196,13 +196,12 @@ def sync_heroku_buckets(c, *, source, destination, folders=[]):
         c, source, "S3_BUCKET_NAME"
     )
 
-
     # The `--size-only` flag means we don't have to compute the md5
     # hash of every media file, potentially increasing performance
     cmd_template = "s3 sync --size-only --delete s3://{source_bucket_name}/{folder} s3://{destination_bucket_name}/{folder}"
     if folders:
         for folder in folders:
-            print('Syncing media folder `{}` (this may take a while).'.format(folder))
+            print('Syncing media folder `{}`. This operation may take a while, and will be interrupted if your computer goes to sleep, is powered off, or loses its connection to the internet.'.format(folder))
             aws_cmd = cmd_template.format(
                 source_bucket_name=source_bucket_name,
                 destination_bucket_name=destination_bucket_name,
@@ -210,7 +209,7 @@ def sync_heroku_buckets(c, *, source, destination, folders=[]):
             )
             aws(c, aws_cmd, destination_access_key_id, destination_secret_access_key)
     else:
-        print('Syncing all media folders (this may take a while).')
+        print('Syncing all media folders. This operation may take a while, and will be interrupted if your computer goes to sleep, is powered off, or loses its connection to the internet.')
         aws_cmd = cmd_template.format(
             source_bucket_name=source_bucket_name,
             destination_bucket_name=destination_bucket_name,

--- a/fabfile.py
+++ b/fabfile.py
@@ -325,18 +325,10 @@ def pull_images_from_s3_heroku(c, app_instance):
 
 
 def delete_local_renditions(local_database_name=LOCAL_DATABASE_NAME):
+    print('Deleting local image renditions')
     try:
         local(
-            'sudo -u postgres psql  -d {database_name} -c "DELETE FROM images_rendition;"'.format(
-                database_name=local_database_name
-            )
-        )
-    except:
-        pass
-
-    try:
-        local(
-            'sudo -u postgres psql  -d {database_name} -c "DELETE FROM wagtailimages_rendition;"'.format(
+            'sudo -u postgres psql  -d {database_name} -c "DELETE FROM home_customrendition;"'.format(
                 database_name=local_database_name
             )
         )
@@ -345,9 +337,10 @@ def delete_local_renditions(local_database_name=LOCAL_DATABASE_NAME):
 
 
 def delete_staging_renditions(c):
+    print('Deleting staging image renditions')
     check_if_logged_in_to_heroku(c)
     local(
-        'heroku pg:psql --app {app} -c "DELETE FROM wagtailimages_rendition;"'.format(
+        'heroku pg:psql --app {app} -c "DELETE FROM home_customrendition;"'.format(
             app=STAGING_APP_INSTANCE
         )
     )

--- a/fabfile.py
+++ b/fabfile.py
@@ -185,7 +185,7 @@ def sync_heroku_buckets(c, *, source, destination, folders=[]):
     destination_bucket_name = get_heroku_variable(
         c, destination, "S3_BUCKET_NAME"
     )
-    if destination_bucket_name == 'newamericadotorg':
+    if destination_bucket_name == PRODUCTION_APP_INSTANCE:
         raise RuntimeError("Production bucket used as destination for sync_heroku_buckets. Please delete this check if you're absolutely sure you want to do this")
     destination_access_key_id = get_heroku_variable(c, destination, "AWS_ACCESS_KEY_ID")
     destination_secret_access_key = get_heroku_variable(

--- a/fabfile.py
+++ b/fabfile.py
@@ -3,7 +3,7 @@ from invoke.exceptions import Exit
 from invoke.tasks import task
 
 PRODUCTION_APP_INSTANCE = "newamericadotorg"
-STAGING_APP_INSTANCE = "na-develop"
+STAGING_APP_INSTANCE = "na-staging"
 
 LOCAL_MEDIA_FOLDER = "/vagrant/media"
 LOCAL_IMAGES_FOLDER = "/vagrant/media/original_images"

--- a/fabfile.py
+++ b/fabfile.py
@@ -179,6 +179,8 @@ def sync_heroku_buckets(c, *, source, destination):
     destination_bucket_name = get_heroku_variable(
         c, destination, "S3_BUCKET_NAME"
     )
+    if destination_bucket_name == 'newamericadotorg':
+        raise RuntimeError("Production bucket used as destination for sync_heroku_buckets. Please delete this check if you're absolutely sure you want to do this")
     destination_access_key_id = get_heroku_variable(c, destination, "AWS_ACCESS_KEY_ID")
     destination_secret_access_key = get_heroku_variable(
         c, destination, "AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
Refs #1401 

This PR improves (or attempts to improve) the `sync-staging-from-production` fabric task by improving performance (the time it takes the command to run overall) and improved feedback to the user. Specifically:

1. Printing what media directories are being synced. These commands can take a long time so we should at least see a message stating so.
2. Restricted the number of files being synced by only syncing documents and original images. This should make it not take as long.
3. Use `aws s3 sync --size-only` to reduce the number of operations needed per file to be synced, which I think might improve performance (though I have not measured this). This option makes file comparisons based on size only, rather than a hash of the file's contents.

### Other notes

* Fixed #1552 
* I'm not sure S3 replica rules are what we want, it looks like these are for creating a system to automatically and immediately copy data from one S3 bucket to another, rather than doing so on-demand. I feel like having files automatically replicated to staging might cause problems?