### PR TITLE
Upgrade wagtail from 2.10.1 to 2.10.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.0.3
-Wagtail==2.10.1
+Wagtail==2.10.2
 
 # Packages that depend on Django version
 Celery==4.4.0


### PR DESCRIPTION
Bugfix only release, see notes here:

https://docs.wagtail.io/en/stable/releases/2.10.2.html