### PR TITLE
Search content type

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.apps import apps
 from django.shortcuts import redirect
+from django.utils.functional import cached_property
 from datetime import datetime
 from pytz import timezone
 from django.db.models import Q
@@ -368,9 +369,13 @@ class ProgramSimplePage(AbstractSimplePage):
     parent_page_types = ['programs.Program', 'programs.Subprogram']
     subpage_types = ['home.RedirectPage']
 
+    @cached_property
+    def program(self):
+        return self.get_parent().specific
+
     def get_context(self, request):
         context = super(ProgramSimplePage, self).get_context(request)
-        context['program'] = self.get_parent().specific
+        context['program'] = self.program
 
         return context
 
@@ -388,7 +393,7 @@ class ProgramAboutHomePage(ProgramSimplePage):
 
     def get_context(self, request):
         context = super().get_context(request)
-        context['program'] = self.get_parent().specific
+        context['program'] = self.program
 
         if getattr(request, 'is_preview', False):
             program_context = context['program'].get_context(request)
@@ -406,9 +411,13 @@ class ProgramAboutPage(ProgramSimplePage):
     class Meta:
         verbose_name = 'Program About Page'
 
+    @cached_property
+    def program(self):
+        return self.get_parent().get_parent().specific
+
     def get_context(self, request):
         context = super(ProgramSimplePage, self).get_context(request)
-        context['program'] = self.get_parent().get_parent().specific
+        context['program'] = self.program
 
         if getattr(request, 'is_preview', False):
             program_context = context['program'].get_context(request)

--- a/home/models.py
+++ b/home/models.py
@@ -393,7 +393,6 @@ class ProgramAboutHomePage(ProgramSimplePage):
 
     def get_context(self, request):
         context = super().get_context(request)
-        context['program'] = self.program
 
         if getattr(request, 'is_preview', False):
             program_context = context['program'].get_context(request)
@@ -413,10 +412,10 @@ class ProgramAboutPage(ProgramSimplePage):
 
     @cached_property
     def program(self):
-        return self.get_parent().get_parent().specific
+        return Page.objects.ancestor_of(self).type(AbstractProgram).order_by('-depth').first().specific
 
     def get_context(self, request):
-        context = super(ProgramSimplePage, self).get_context(request)
+        context = super().get_context(request)
         context['program'] = self.program
 
         if getattr(request, 'is_preview', False):

--- a/newamericadotorg/api/search/serializers.py
+++ b/newamericadotorg/api/search/serializers.py
@@ -4,7 +4,7 @@ from wagtail.core.models import Page
 from wagtail.images.views.serve import generate_image_url
 
 from person.models import Person
-from home.models import Post
+from home.models import Post, Program
 from event.models import Event
 
 from newamericadotorg.api.helpers import get_content_type
@@ -23,13 +23,18 @@ class SearchSerializer(ModelSerializer):
             data['last_name'] = obj.last_name
             data['position'] = obj.position_at_new_america
         elif isinstance(obj, Post) or type(obj) == Event:
-            data['story_image'] = generate_image_url(obj.story_image, 'max-300x240') if obj.story_image else None
             data['date'] = obj.date
-            data['programs'] = PostProgramSerializer(obj.parent_programs, many=True).data
 
         if isinstance(obj, Post):
             data['authors'] = AuthorSerializer(obj.post_author, many=True, context=self.context).data
+        
+        data['story_image'] = generate_image_url(obj.story_image, 'max-300x240') if getattr(obj, 'story_image', None) else None
 
+        if hasattr(obj, 'parent_programs'):
+            data['programs'] = PostProgramSerializer(obj.parent_programs, many=True).data
+        else:
+            programs = Program.objects.ancestor_of(obj).order_by('-depth')
+            data['programs'] = PostProgramSerializer(programs, many=True).data
 
         data['content_type'] = get_content_type(obj)
         return data

--- a/newamericadotorg/assets/react/components/ContentCards.js
+++ b/newamericadotorg/assets/react/components/ContentCards.js
@@ -146,12 +146,10 @@ export const PublicationListItem = ({ post }) => (
           )}
         </div>
       )}
-      {post.programs && (
-        <div className="h6 card__text__program caption margin-top-5 margin-top-md-15 margin-bottom-0">
-          {post.programs[0] ? post.programs[0].name : ''}{' '}
-          {post.content_type ? post.content_type.name : ''}
-        </div>
-      )}
+      <div className="h6 card__text__program caption margin-top-5 margin-top-md-15 margin-bottom-0">
+        {post.programs && post.programs[0] ? post.programs[0].name + ' ' : ''}
+        {post.content_type ? post.content_type.name : ''}
+      </div>
     </div>
   </div>
 );


### PR DESCRIPTION
Addresses https://github.com/newamericafoundation/newamerica-cms/issues/1530

- Display content type even if no program is found for publication listing cards, including search
- Find the program even for non Posts and for models linked to Program via tree structure rather than `parent_programs`
- Look for story image via `getattr` to find story images on non Posts

However, some page types still don't have a story image, and I wasn't sure if this was something you wanted to add as part of this, so not all pages will show images in search.