### PR TITLE
Fix location widget

### DIFF
--- a/newamericadotorg/wagtailadmin/widgets.py
+++ b/newamericadotorg/wagtailadmin/widgets.py
@@ -12,4 +12,4 @@ class LocationWidget(widgets.TextInput):
         if attrs is not None:
             context.update(attrs)
 
-        return loader.get_template(self.template_name).render(attrs)
+        return loader.get_template(self.template_name).render(context)


### PR DESCRIPTION
Make location widget initialise with the previous value, preventing it needing to be entered anew each draft to prevent form errors