### PR TITLE
Pdf images

### DIFF
--- a/report/templates/report/figure.html
+++ b/report/templates/report/figure.html
@@ -12,7 +12,7 @@
     </div>
   {% endif %}
   <div class="figure__image">
-      <img src="https://s3.amazonaws.com/newamericadotorg/{{value.image.file.name}}"/>
+      <img src="{{ value.image.file.url }}"/>
   </div>
   {% if value.image.caption or value.image.source %}
     <figcaption>

--- a/report/templates/report/figure_iframe.html
+++ b/report/templates/report/figure_iframe.html
@@ -3,7 +3,7 @@
 <figure class="figure {{value.fallback_image_align}} {{value.fallback_image_width|temp_image_width_map}}">
 
   <div class="figure__image">
-      <img src="https://s3.amazonaws.com/newamericadotorg/{{value.fallback_image.file.name}}"/>
+      <img src="{{ value.fallback_image.file.url }}"/>
   </div>
 
   {% if value.fallback_image.caption or value.fallback_image.source %}

--- a/report/templates/report/pdf.html
+++ b/report/templates/report/pdf.html
@@ -33,7 +33,7 @@
           {% if page.partner_logo %}
             {% image page.partner_logo height-36 as partner_logo %}
             <div class="logo-img-wrapper">
-              <img src="https://s3.amazonaws.com/newamericadotorg/{{ partner_logo.file.name }}"/>
+              <img src="{{ partner_logo.url }}"/>
             </div>
           {% endif %}
         </div>
@@ -41,7 +41,7 @@
           <div class="title-wrapper">
             <div class="cover-photo">
               {% image page.story_image fill-984x450 as cover_img %}
-              <img src="https://s3.amazonaws.com/newamericadotorg/{{ cover_img.file.name }}" />
+              <img src="{{ cover_img.url }}" />
             </div>
             <label class="date block">{{page.date|date:"F Y"}}</label>
             <h1 class="promo">{{page.title}}</h1>


### PR DESCRIPTION
Remove hardcoded urls from pdf templates, which were preventing image urls from being generated properly for staging images.