### PR TITLE
1538 pdf image height

### DIFF
--- a/report/templates/report/figure.html
+++ b/report/templates/report/figure.html
@@ -12,7 +12,7 @@
     </div>
   {% endif %}
   <div class="figure__image">
-      <img src="https://s3.amazonaws.com/newamericadotorg/{{value.image.file.name}}"/>
+      <img src="{{ value.image.file.url }}"/>
   </div>
   {% if value.image.caption or value.image.source %}
     <figcaption>

--- a/report/templates/report/figure_iframe.html
+++ b/report/templates/report/figure_iframe.html
@@ -3,7 +3,7 @@
 <figure class="figure {{value.fallback_image_align}} {{value.fallback_image_width|temp_image_width_map}}">
 
   <div class="figure__image">
-      <img src="https://s3.amazonaws.com/newamericadotorg/{{value.fallback_image.file.name}}"/>
+      <img src="{{ value.fallback_image.file.url }}"/>
   </div>
 
   {% if value.fallback_image.caption or value.fallback_image.source %}

--- a/report/templates/report/pdf.html
+++ b/report/templates/report/pdf.html
@@ -33,7 +33,7 @@
           {% if page.partner_logo %}
             {% image page.partner_logo height-36 as partner_logo %}
             <div class="logo-img-wrapper">
-              <img src="https://s3.amazonaws.com/newamericadotorg/{{ partner_logo.file.name }}"/>
+              <img src="{{ partner_logo.url }}"/>
             </div>
           {% endif %}
         </div>
@@ -41,7 +41,7 @@
           <div class="title-wrapper">
             <div class="cover-photo">
               {% image page.story_image fill-984x450 as cover_img %}
-              <img src="https://s3.amazonaws.com/newamericadotorg/{{ cover_img.file.name }}" />
+              <img src="{{ cover_img.url }}" />
             </div>
             <label class="date block">{{page.date|date:"F Y"}}</label>
             <h1 class="promo">{{page.title}}</h1>

--- a/report/templates/report/pdf_style.html
+++ b/report/templates/report/pdf_style.html
@@ -520,6 +520,7 @@
     .figure__image > img {
       display: block;
       width: 100%;
+      max-height: 637pt;
       height: auto;
       margin: 0 auto;
     }


### PR DESCRIPTION
Fixes #1538 

Notes:
- I pulled in Jacob's fix for PDF images so that I would be able to view images in order to test them.
- PDF generation wasn't working for me locally but I tested by printing to PDF in my browser (from the print view, which is when you add `/print/` to the end of a report url). 
- For the `max-height` I used the largest value that l thought should work according to the page margins indicated by the CSS, but I'm not entirely sure it's right because I wasn't able to test properly.
- Arguably I maybe should have put the max height on `img` not `.figure__image > img` but this will make a big difference regardless. (Maybe we would need it on `img` if people insert images inside a rich text block? But I don't think we use that much and I'm frustrated with my inability to test this properly, at this point.)


To test:
- Starting on `main`, upload an image that is tall and not awfully wide. My test image was 1387 × 3147px.
- Verify that your image extends off the bottom of the page when you generate the pdf
- Switch to `1538-pdf-image-height` and regenerate the pdf
- Verify that your image no longer extends off the bottom of the page
