### PR TITLE
Update wagtail from 2.10 to 2.11

### DIFF
--- a/in_depth/models.py
+++ b/in_depth/models.py
@@ -192,7 +192,7 @@ class InDepthProfile(Page):
 
     body = StreamField([
         ('introduction', blocks.RichTextBlock()),
-        ('heading', blocks.CharBlock(classname='full title')),
+        ('heading', blocks.CharBlock(form_classname='full title')),
         ('paragraph', blocks.RichTextBlock()),
         ('image', ImageChooserBlock(icon='image')),
         ('video', EmbedBlock(icon='media')),

--- a/newamericadotorg/blocks.py
+++ b/newamericadotorg/blocks.py
@@ -430,7 +430,7 @@ class SessionsBlock(blocks.StreamBlock):
 
 class Body(blocks.StreamBlock):
 	introduction = blocks.RichTextBlock(icon="openquote")
-	heading = blocks.CharBlock(classname='full title', icon="title", template="blocks/heading.html")
+	heading = blocks.CharBlock(form_classname='full title', icon="title", template="blocks/heading.html")
 	paragraph = blocks.RichTextBlock()
 	inline_image = CustomImageBlock(icon='image')
 	video = EmbedBlock(icon='media')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==3.0.7
-Wagtail==2.10.2
+Django==3.0.11
+Wagtail==2.11.3
 
 # Packages that depend on Django version
 Celery==4.4.0


### PR DESCRIPTION
Fixes #1579 

This PR updates wagtail to the latest version. The only changes I could find that needed to be made to our code were some keyword deprecations for styling blocks in the admin. 

Other changes of note:

* I took the opportunity to upgrade us to the latest version of the Django 3.0.x line, which fixes some bugs.
* ~The `fellowship_year` field has a set of choices based on the current year, and since we're in a new year, a migration was generated to populate those choices. I've included it in this branch since otherwise CI fails.~