### PR TITLE
Elasticsearch 5 upgrade

### DIFF
--- a/newamericadotorg/settings/test.py
+++ b/newamericadotorg/settings/test.py
@@ -13,7 +13,7 @@ DATABASES = {
 WAGTAILSEARCH_BACKENDS = {
     'default': {
         'BACKEND': 'search.backend',
-        'URLS': ["http://localhost:9200/"],
+        'URLS': ["http://localhost:9200"],
         'INDEX': 'test',
         'TIMEOUT': 1500,
         'INDEX_SETTINGS': {

--- a/newamericadotorg/settings/test.py
+++ b/newamericadotorg/settings/test.py
@@ -16,6 +16,13 @@ WAGTAILSEARCH_BACKENDS = {
         'URLS': ["http://localhost:9200/"],
         'INDEX': 'test',
         'TIMEOUT': 1500,
+        'INDEX_SETTINGS': {
+            'settings': {
+                'index': {
+                    'number_of_shards': 1,
+                },
+            },
+        }
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ psycopg2==2.8.4
 WeasyPrint==51
 python-docx==0.8.10
 boto3==1.12.5
-elasticsearch==2.4.1
+elasticsearch==5.5.3
 redis==3.4.1
 #See https://github.com/wagtail/wagtail-autocomplete
 wagtail-autocomplete==0.6

--- a/scripts/travis/install_elasticsearch.sh
+++ b/scripts/travis/install_elasticsearch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
-dpkg -i --force-confnew elasticsearch-2.4.6.deb
+curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.deb
+dpkg -i --force-confnew elasticsearch-5.6.16.deb
 
 # Enable script scoring
 cat << EOF >> /etc/elasticsearch/elasticsearch.yml

--- a/scripts/travis/install_elasticsearch.sh
+++ b/scripts/travis/install_elasticsearch.sh
@@ -3,6 +3,8 @@
 curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.deb
 dpkg -i --force-confnew elasticsearch-5.6.16.deb
 
+chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+
 # Enable script scoring
 cat << EOF >> /etc/elasticsearch/elasticsearch.yml
 script.inline: on

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -20,8 +20,8 @@ echo "Downloading Elasticsearch..."
 set +e
 apt-get remove -y --purge elasticsearch
 set -e
-wget -q https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.2/elasticsearch-2.4.2.deb
-dpkg -i elasticsearch-2.4.2.deb
+wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.deb
+dpkg -i elasticsearch-5.6.16.deb
 
 # Enable script scoring
 cat << EOF >> /etc/elasticsearch/elasticsearch.yml
@@ -29,9 +29,12 @@ script.inline: on
 script.search: on
 EOF
 
+# Reduce memory to fit in default virtualvox vm
+sed -i 's/^\-Xms.*/\-Xms512m/' /etc/elasticsearch/jvm.options
+sed -i 's/^\-Xmx.*/\-Xmx512m/' /etc/elasticsearch/jvm.options
+
 systemctl enable elasticsearch
 systemctl start elasticsearch
-
 
 # Create database (let it fail because database may exist)
 set +e


### PR DESCRIPTION
Fixes #1613 

Will require some kind of re-indexing and/or migration of the Elastic Search service on Heroku.

I'll also note that we may want to consider also upgrading to ES 6 at some point, as ES 5 is quite out of date as well.