### PR TITLE
Use flexbox ordering to sort search buckets

### DIFF
--- a/newamericadotorg/assets/react/home-panels/pages/Search.js
+++ b/newamericadotorg/assets/react/home-panels/pages/Search.js
@@ -43,7 +43,7 @@ function SearchResultList({results, header, bucket, isFetching, hasNext, hasPrev
   }
 
   return (
-    <div className={`search-results search-results--${bucket}`}>
+    <div className={`search-results search-results--${bucket} ${(results.length === 0) && 'search-results--empty'}`}>
       <h2>{header}</h2>
 
       {(results.length === 0)
@@ -148,7 +148,7 @@ function SearchBucket({query, name, bucket, endpoint, showEmpty, pageSize}) {
   }, [query, paginationFilter]);
 
   return (
-    <div>
+    <>
       {(results.length > 1 || showEmpty) && <SearchResultList
         results={results}
         header={name}
@@ -159,7 +159,7 @@ function SearchBucket({query, name, bucket, endpoint, showEmpty, pageSize}) {
         hasPrevious={!!previousPaginationFilter}
         fetchPrevious={() => setPaginationFilter(previousPaginationFilter)}
        />}
-    </div>
+    </>
   )
 }
 

--- a/newamericadotorg/assets/react/home-panels/pages/Search.scss
+++ b/newamericadotorg/assets/react/home-panels/pages/Search.scss
@@ -1,5 +1,7 @@
 .home__panels__search {
   margin-bottom: 115px;
+  display: flex;
+  flex-direction: column;
 }
 
 .search-results {
@@ -9,6 +11,10 @@
 
   &--loading {
     margin-bottom: 60px;
+  }
+
+  &--empty {
+    order: 2;
   }
 
   &__list {


### PR DESCRIPTION
- Moves empty buckets to end of list
- Use fragment for search bucket so that search results won't be wrapped in a div

Closes #1608
Alternative to #1631