### PR TITLE
Use flexbox in order to avoid safari bug

### DIFF
--- a/newamericadotorg/assets/react/report/components/Heading.scss
+++ b/newamericadotorg/assets/react/report/components/Heading.scss
@@ -19,6 +19,10 @@
     @media (min-height: 1200px) {
       height: calc(100vh - 70px - 2.3vh);
     }
+
+    .single-page & {
+      margin-bottom: 80px;
+    }
   }
 }
 

--- a/newamericadotorg/assets/react/report/components/Heading.scss
+++ b/newamericadotorg/assets/react/report/components/Heading.scss
@@ -67,20 +67,9 @@
     flex-grow: 1;
     width: 100%;
     margin: 0;
-    padding-bottom: 28px;
     max-width: none;
-
-    @media (min-height: 800px) {
-      padding-bottom: calc(28px - 20px + 2.5vh);
-    }
-
-    @media (min-height: 1200px) {
-      padding-bottom: calc(28px - 20px + 3vh);
-    }
-
-    @include media-breakpoint-down(mobile) {
-      padding-bottom: 40px;
-    }
+    display: flex;
+    flex-direction: column;
   }
 
   .card__image__background {
@@ -94,8 +83,7 @@
 }
 
 .card__image__background-image {
-  height: 100%;
-  width: 100%;
+  flex-grow: 1;
   background-color: #efefef;
   background-repeat: no-repeat;
   background-size: cover;


### PR DESCRIPTION
Bug: full-bleed header image for reports not showing at all on safari, because of a bug that makes height:100% not work with flexbox (see https://stackoverflow.com/a/33644245)

Full-bleed, single page: https://www.newamerica.org/political-reform/reports/choosing-to-vote-as-usual/
Full-bleed, multi-page: https://www.newamerica.org/education-policy/reports/transforming-financing/