### PR TITLE
Hide redirect projects in search

### DIFF
--- a/programs/models.py
+++ b/programs/models.py
@@ -383,6 +383,11 @@ class Project(Subprogram):
         ObjectList(Subprogram.settings_panels, heading='Settings', classname='settings'),
     ])
 
+    @classmethod
+    def get_indexed_objects(cls):
+        # do not add projects with a redirect page to the search index
+        return cls.objects.filter(redirect_page__isnull=True)
+
     class Meta:
         ordering = ('title',)
         verbose_name = 'Project'

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -1,37 +1,36 @@
-from wagtail.tests.utils import WagtailPageTests
 from wagtail.core.models import Page
+from wagtail.tests.utils import WagtailPageTests
 
-from home.models import HomePage, OrgSimplePage, ProgramSimplePage, JobsPage, SubscribePage, RedirectPage, ProgramAboutHomePage
-
-from .models import Program, Subprogram, ProgramSubprogramRelationship, PublicationsPage, Project
-
+from article.models import AllArticlesHomePage, Article, ProgramArticlesPage
+from blog.models import AllBlogPostsHomePage, ProgramBlogPostsPage
+from book.models import AllBooksHomePage, ProgramBooksPage
+from event.models import AllEventsHomePage, ProgramEventsPage
+from home.models import (
+    HomePage, JobsPage, OrgSimplePage, ProgramAboutHomePage, ProgramSimplePage,
+    RedirectPage, SubscribePage
+)
+from issue.models import IssueOrTopic, TopicHomePage
+from other_content.models import ProgramOtherPostsPage
+from person.models import (
+    BoardAndLeadershipPeoplePage, OurPeoplePage, ProgramPeoplePage
+)
+from podcast.models import AllPodcastsHomePage, ProgramPodcastsPage
+from policy_paper.models import (
+    AllPolicyPapersHomePage, ProgramPolicyPapersPage
+)
+from press_release.models import (
+    AllPressReleasesHomePage, ProgramPressReleasesPage
+)
+from quoted.models import AllQuotedHomePage, ProgramQuotedPage
+from report.models import ReportsHomepage
+from survey.models import SurveysHomePage
 from weekly.models import Weekly
 
-from article.models import AllArticlesHomePage, ProgramArticlesPage, Article
+from .models import (
+    Program, ProgramSubprogramRelationship, Project, PublicationsPage,
+    Subprogram
+)
 
-from event.models import AllEventsHomePage, ProgramEventsPage
-
-from blog.models import AllBlogPostsHomePage, ProgramBlogPostsPage
-
-from book.models import AllBooksHomePage, ProgramBooksPage
-
-from person.models import OurPeoplePage, BoardAndLeadershipPeoplePage, ProgramPeoplePage
-
-from podcast.models import AllPodcastsHomePage, ProgramPodcastsPage
-
-from policy_paper.models import AllPolicyPapersHomePage, ProgramPolicyPapersPage
-
-from press_release.models import AllPressReleasesHomePage, ProgramPressReleasesPage
-
-from quoted.models import AllQuotedHomePage, ProgramQuotedPage
-
-from issue.models import IssueOrTopic, TopicHomePage
-
-from report.models import ReportsHomepage
-
-from other_content.models import ProgramOtherPostsPage
-
-from survey.models import SurveysHomePage
 
 class ProgramsTests(WagtailPageTests):
     """

--- a/programs/tests.py
+++ b/programs/tests.py
@@ -1,3 +1,7 @@
+import io
+
+from django.core import management
+from django.test import TestCase
 from wagtail.core.models import Page
 from wagtail.tests.utils import WagtailPageTests
 
@@ -24,6 +28,7 @@ from press_release.models import (
 from quoted.models import AllQuotedHomePage, ProgramQuotedPage
 from report.models import ReportsHomepage
 from survey.models import SurveysHomePage
+from test_factories import PostFactory
 from weekly.models import Weekly
 
 from .models import (
@@ -148,3 +153,49 @@ class ProgramsTests(WagtailPageTests):
                 SurveysHomePage
             }
         )
+
+
+class SearchTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        home_page = PostFactory.create_homepage()
+
+        cls.program = PostFactory.create_program(
+            home_page=home_page,
+            program_data={
+                'title': 'Robots Program'
+            }
+        )
+
+        cls.project1 = cls.program.add_child(
+            instance=Project(
+                title='Cyborg Project',
+                name='Cyborg Project',
+                description='Secret',
+            )
+        )
+
+        cls.redirect_project = cls.program.add_child(
+            instance=Project(
+                title='Cyborg Project',
+                name='Cyborg Project',
+                description='Secret',
+                redirect_page=cls.project1,
+            )
+        )
+
+    def setUp(self):
+        management.call_command('update_index', stdout=io.StringIO(), chunk_size=50)
+
+    def test_program_search_excludes_redirect_projects(self):
+        qs = (
+            Page.objects
+            .live()
+            .public()
+            .type((Program, Subprogram))
+            .search('cyborg', partial_match=False)
+        )
+
+        found_pks = {x.pk for x in qs}
+        self.assertIn(self.project1.pk, found_pks)
+        self.assertNotIn(self.redirect_project.pk, found_pks)


### PR DESCRIPTION
Fixes #1639 

In order for this to change take effect on staging/production/etc., I believe we have to run the `update_index` management command.