### PR TITLE
Skip elasticsearch date test 

### DIFF
--- a/newamericadotorg/api/search/tests.py
+++ b/newamericadotorg/api/search/tests.py
@@ -82,6 +82,7 @@ class SearchAPITests(APITestCase):
 
 
 @unittest.skipUnless(TEST_ELASTICSEARCH, "Elasticsearch tests not enabled")
+@unittest.skip('Inconsistent test, needs further analysis')
 class SearchAPIDateTests2(APITestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
Can reconsider this after upgrading to ES5 (#1623), which it might fix this problem.