### PR TITLE
1634 the thread links

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -46,18 +46,18 @@
 	</section>
 	<section class="container--full-width beige homepage__weekly-promo-section scroll-target" data-scroll-trigger-point="bottom" data-scroll-top-offset="25vh">
 		<div class="container">
-			<a href="/weekly" class="homepage__promo-link">
+			<a href="/the-thread" class="homepage__promo-link">
 				<h1 class="promo margin-0">
 					<div class="block">
-						<span><em>New ideas & voices in policy,</em></span>
+						<span><em>Where policy, equity, and</em></span>
 					</div>
 					<div class="block">
-						<span><em>delivered every Thursday</em></span>
+						<span><em>culture come together.</em></span>
 					</div>
 				</h1>
 				<h3 class="margin-top-35 margin-bottom-0 homepage__promo-link">
 					<div class="block">
-						<span><em>Read our digital magazine, The Weekly</em></span>
+						<span><em>Read and subscribe to The Thread, a blog by New America.</em></span>
 					</div>
 				</h3>
 			</a>

--- a/home/templates/tags/top_menu.html
+++ b/home/templates/tags/top_menu.html
@@ -26,7 +26,7 @@
         <li class="mobile-menu__link__main"><a href="#">Channels</a>
             <div class="mobile-menu__toggle flip-arrow-black rotate"></div>
             <ul class="vertical menu">
-                <li class="mobile-menu__link__secondary"><a href="/weekly/">New America Weekly</a></li>
+                <li class="mobile-menu__link__secondary"><a href="/the-thread/">The Thread</a></li>
                 <li class="mobile-menu__link__secondary"><a href="https://context.newamerica.org/">Context on Medium</a></li>
                 <li class="mobile-menu__link__secondary"><a href="http://www.slate.com/articles/technology/future_tense.html">Future Tense on Slate</a></li>
             </ul>
@@ -46,7 +46,7 @@
                 <li class="mobile-menu__link__secondary"><a href="/books/">Books</a></li>
                 <li class="mobile-menu__link__secondary"><a href="/in-depth/">In Depth</a></li>
                 <li class="mobile-menu__link__secondary"><a href="/in-the-news/">In the News</a></li>
-                <li class="mobile-menu__link__secondary"><a href="/weekly/">New America Weekly</a></li>
+                <li class="mobile-menu__link__secondary"><a href="/the-thread/">The Thread</a></li>
                 <li class="mobile-menu__link__secondary"><a href="/podcasts/">Podcasts</a></li>
                 <li class="mobile-menu__link__secondary"><a href="/policy-papers/">Policy Papers</a></li>
                 <li class="mobile-menu__link__secondary"><a href="/press-releases/">Press Releases</a></li>
@@ -150,7 +150,7 @@
                                     <h1 class='header__link-group__heading'>Channels</h1>
                                 </div>
                                 <div class='header__link-group__secondary__entry-group'>
-                                    <a class="header__link-group__main-element" href="/weekly/">New America Weekly</a>
+                                    <a class="header__link-group__main-element" href="/the-thread/">The Thread</a>
                                     <a class="header__link-group__main-element" href="https://context.newamerica.org/">Context on Medium</a>
                                     <a class="header__link-group__main-element" href="http://www.slate.com/articles/technology/future_tense.html">Future Tense on Slate</a>
                                 </div>
@@ -177,7 +177,7 @@
                                 <li ><a class='header__simple-link-group__element' href="/books/">Books</a></li>
                                 <li ><a class='header__simple-link-group__element' href="/in-depth/">In Depth</a></li>
                                 <li ><a class='header__simple-link-group__element' href="/in-the-news/">In the News</a></li>
-                                <li ><a class='header__simple-link-group__element' href="/weekly/">New America Weekly</a></li>
+                                <li ><a class='header__simple-link-group__element' href="/the-thread/">The Thread</a></li>
                                 <li ><a class='header__simple-link-group__element' href="/podcasts/">Podcasts</a></li>
                                 <li ><a class='header__simple-link-group__element' href="/policy-papers/">Policy Papers</a></li>
                                 <li ><a class='header__simple-link-group__element' href="/press-releases/">Press Releases</a></li>

--- a/newamericadotorg/assets/react/mobile-menu/components/Tabs.js
+++ b/newamericadotorg/assets/react/mobile-menu/components/Tabs.js
@@ -18,6 +18,9 @@ export const PrimaryTab = ({switchTab}) => (
         <a href="/publications/">Publications</a>
       </h6>
       <h6>
+        <a href="/the-thread/">The Thread</a>
+      </h6>
+      <h6>
         <a href="/events/">Events</a>
       </h6>
     </div>

--- a/newamericadotorg/templates/components/header_dropdowns.html
+++ b/newamericadotorg/templates/components/header_dropdowns.html
@@ -13,6 +13,11 @@
     </a>
   </div>
   <div class="header__nav__dropdown">
+    <a href="/the-thread/" class="header__nav__dropdown__header no-drop">
+      <h4 class="link inline"><span><u>The Thread</u></span></h4>
+    </a>
+  </div>
+  <div class="header__nav__dropdown">
     <a href="/events/" class="header__nav__dropdown__header no-drop">
       <h4 class="link inline"><span><u>Events</u></span></h4>
     </a>


### PR DESCRIPTION
Merge and deploy this when The Thread is ready to go live.

Changes the homepage to link to the thread. Also changes links in `top_menu.html` but they don't appear to show up anywhere.