### PR TITLE
Fix styles for dataviz on non-reports

### DIFF
--- a/newamericadotorg/assets/scss/pages/post/body/_na-dataviz.scss
+++ b/newamericadotorg/assets/scss/pages/post/body/_na-dataviz.scss
@@ -1,5 +1,8 @@
 .na-dataviz,
 .wrapper--streamfield-block {
+  position: relative;
+  z-index: 1;
+
   &.full-width{
     width: 100vw;
     margin-left: calc(-50vw + 50%);
@@ -11,7 +14,11 @@
     margin-left: calc(-50vw + 50% + 15px);
 
     @media (min-width: 1230px) {
-      margin-left: -275px;
+      margin-left: -250px;
+
+      .report & {
+        margin-left: -275px;
+      }
     }
   }
 }


### PR DESCRIPTION
- don't hide under right sidebar column (so it's clickable there)
- change margin left except for in reports

to test:
- on `main` go to http://localhost:8000/admin/pages/27624/edit/ and make the datawrapper block site width
- view the live page and confirm
  - you can't click to go to the next page of the table
  - the table is shifted a little bit to the left (scroll down, then up a bit to reveal the header to compare)
    ![Screen Shot 2021-04-27 at 15 14 45](https://user-images.githubusercontent.com/1051450/116299437-b4b48200-a76b-11eb-892e-3ecf5b83b966.png)
- switch to `1571-full-width-figure` and confirm that now
  - you can click to go to the next page of the table
  - the table is aligned correctly
    ![Screen Shot 2021-04-27 at 15 15 53](https://user-images.githubusercontent.com/1051450/116299465-ba11cc80-a76b-11eb-960c-13bab5496f2a.png)


Closes #1571 