### PR TITLE
Headless preview

### DIFF
--- a/newamericadotorg/api/meta/views.py
+++ b/newamericadotorg/api/meta/views.py
@@ -1,14 +1,19 @@
+from django.contrib.contenttypes.models import ContentType
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
+from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from wagtail_headless_preview.models import PagePreview
 
 from home.models import HomePage
 from programs.models import Program
 
 from newamericadotorg.settings.context_processors import content_types
 from newamericadotorg.api.program.serializers import ProgramSerializer, SubscriptionSegmentSerializer
+from newamericadotorg.api.report.serializers import ReportDetailSerializer
+
 
 @method_decorator([cache_page(2*60)], name='get')
 class MetaList(APIView):
@@ -52,3 +57,32 @@ class ContentList(APIView):
             'previous': None,
             'results': types
         })
+
+
+class PreviewView(APIView):
+    def get(self, request):
+        try:
+            app_label, model = self.request.GET['content_type'].split('.')
+            content_type = ContentType.objects.get(app_label=app_label, model=model)
+            token = self.request.GET['token']
+        except Exception:
+            return Response(
+                {'detail': f'Unable to preview for content type {model}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if content_type.model == 'report':
+            serializer = ReportDetailSerializer
+        else:
+            return Response(
+                {'detail': f'Unable to preview content type {content_type.model}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        page_preview = PagePreview.objects.get(content_type=content_type, token=token)
+        page = page_preview.as_page()
+        if not page.pk:
+            # fake primary key to stop API URL routing from complaining
+            page.pk = 0
+
+        return Response(serializer(page).data)

--- a/newamericadotorg/api/urls.py
+++ b/newamericadotorg/api/urls.py
@@ -43,6 +43,7 @@ api_urls = [
     url(r'^thread/$', thread_views.ThreadList.as_view()),
     url(r'^thread/(?P<pk>[\d]+)/$', thread_views.ThreadDetail.as_view()),
     url(r'^report/(?P<pk>[\d]+)/$', report_views.ReportDetail.as_view()),
+    url(r'^preview/$', meta_views.PreviewView.as_view()),
     url(r'^home/(?P<pk>[\d]+)/$', home_views.HomeDetail.as_view()),
     #url(r'^api/meta/$', cache_page(60 * 10080)(api_views.MetaList.as_view())),
     url(r'^meta/$', meta_views.MetaList.as_view()),

--- a/newamericadotorg/assets/newamericadotorg.js
+++ b/newamericadotorg/assets/newamericadotorg.js
@@ -95,6 +95,19 @@ function importPageComponents() {
     case 'na-surveys-homepage':
       import(/* webpackChunkName: "na-surveys-homepage-components" */ './react/components.surveys-homepage');
       break;
+    case 'na-preview':
+      const urlParams = new URLSearchParams(window.location.search);
+
+      let element = document.getElementById("na-react__preview");
+
+      element.dataset.token = urlParams.get("token");
+      element.dataset.contentType = urlParams.get("content_type");
+
+      if (urlParams.get("content_type") == "report.report") {
+        element.setAttribute("id", "na-react__report"); // imitate the actual id used by the report page type
+        import(/* webpackChunkName: "na-report-components" */ './react/components.report');
+      }
+      break;
     default:
       break;
   }

--- a/newamericadotorg/assets/react/report/components/BottomNav.js
+++ b/newamericadotorg/assets/react/report/components/BottomNav.js
@@ -68,7 +68,8 @@ const ChapterList = ({
   n,
   reportUrl,
   tooltipContent,
-  setTooltip
+  setTooltip,
+  preview
 }) => (
   <ul
     style={{
@@ -81,7 +82,7 @@ const ChapterList = ({
       style={{ width: "40px", textAlign: "center", lineHeight: "36px" }}
     >
       <Link
-        to={reportUrl}
+        to={preview ? `/preview${reportUrl}` : reportUrl}
         className="ga-track-click"
         data-action="click_bottom_nav"
         data-label="report"
@@ -106,7 +107,7 @@ const ChapterList = ({
         }}
       >
         <Link
-          to={s.url}
+          to={preview ? `/preview${s.url}` : s.url}
           style={{ display: "block" }}
           className="ga-track-click"
           data-action="click_bottom_nav"
@@ -133,7 +134,7 @@ class BottomNav extends Component {
   };
 
   render() {
-    let { section, report, hideAttachments, openMenu } = this.props;
+    let { section, report, hideAttachments, openMenu, preview } = this.props;
     let next = report.sections[section.number],
       previous = report.sections[section.number - 2];
 
@@ -179,7 +180,7 @@ class BottomNav extends Component {
           <div className="report__bottom-nav-bar__button-wrapper">
             {section.number > 1 && (
               <Link
-                to={report.sections[section.number - 2].url}
+                to={preview ? `/preview${report.sections[section.number - 2].url}` : report.sections[section.number - 2].url}
                 className="prev-button ga-track-click"
                 data-action="click_bottom_nav"
                 data-label="report"
@@ -190,7 +191,7 @@ class BottomNav extends Component {
             )}
             {section.number === 1 && (
               <Link
-                to={report.url}
+                to={preview ? `/preview${report.url}` : report.url}
                 className="prev-button"
                 data-action="click_bottom_nav"
                 data-label="report"
@@ -218,12 +219,13 @@ class BottomNav extends Component {
               tooltipContent={this.state.tooltipContent}
               activeIndex={activeIndex}
               n={section.number - 1}
+              preview={preview}
             />
           </div>
           <div className={`report__bottom-nav-bar__button-wrapper next`}>
             {section.number < report.sections.length && (
               <Link
-                to={report.sections[section.number].url}
+                to={preview ? `/preview${report.sections[section.number].url}` : report.sections[section.number].url}
                 className="next-button ga-track-click"
                 data-action="click_bottom_nav"
                 data-label="report"

--- a/newamericadotorg/assets/react/report/components/ContentMenu.js
+++ b/newamericadotorg/assets/react/report/components/ContentMenu.js
@@ -6,10 +6,10 @@ import { connect } from 'react-redux';
 import { PlusX, Home } from '../../components/Icons';
 import { Overlay } from './OverlayMenu';
 
-const Subsection = ({ section, url, closeMenu, action }) => (
+const Subsection = ({ section, url, closeMenu, action, preview }) => (
   <div className="report__menu__subsection">
     <h6 className="margin-0">
-      <Link to={section.url} onClick={closeMenu} className="ga-track-click" data-action={action} data-label="report" data-value="click_menu_subsection">
+      <Link to={preview ? `/preview${section.url}` : section.url} onClick={closeMenu} className="ga-track-click" data-action={action} data-label="report" data-value="click_menu_subsection">
         {section.title}
       </Link>
     </h6>
@@ -31,11 +31,11 @@ const DownArrow = () => (
   </div>
 )
 
-const Section = ({ section, expanded, expand, closeMenu, home, action }) => (
+const Section = ({ section, expanded, expand, closeMenu, home, action, preview }) => (
     <div className={`report__menu__section ${expanded ? 'expanded' : ''}`}>
       <div className="report__menu__section__title row gutter-0">
         <div className="col-11">
-          <Link to={section.url} onClick={closeMenu} className="ga-track-click" data-action={action} data-label="report" data-value="click_menu_section">
+          <Link to={preview ? `/preview${section.url}` : section.url} onClick={closeMenu} className="ga-track-click" data-action={action} data-label="report" data-value="click_menu_section">
             {section.interactive && <InteractiveDiv /> }
             {home && <div className="home-div">
               <Home />
@@ -52,7 +52,7 @@ const Section = ({ section, expanded, expand, closeMenu, home, action }) => (
           { maxHeight: expanded ? (section.subsections.length * 100) + 'px' : 0 }
         }>
           {section.subsections.map((s,i)=>(
-            <Subsection section={s} key={`sub-${i}`} closeMenu={closeMenu} action={action}/>
+            <Subsection preview={preview} section={s} key={`sub-${i}`} closeMenu={closeMenu} action={action}/>
           ))}
         </div>
       }
@@ -96,14 +96,16 @@ class ContentMenu extends Component {
   }
 
   render(){
-    let { report: { url, sections, title }, activeSection, closeMenu, showHome, open } = this.props;
+    let { report: { url, sections, title }, activeSection, closeMenu, showHome, open, preview } = this.props;
+
     return (
       <div className="report__content-menu">
         {showHome &&
-          <Section closeMenu={closeMenu} home={true} section={{ url, title, slug: '', subsections: [] }} landing={false}/>
+          <Section preview={preview} closeMenu={closeMenu} home={true} section={{ url, title, slug: '', subsections: [] }} landing={false}/>
         }
         {sections.map((s,i)=>(
           <Section section={s}
+            preview={preview}
             landing={showHome ? 'click_menu' : 'click_landing'}
             key={`section-${i}`}
             expand={this.expand}

--- a/newamericadotorg/assets/react/report/index.js
+++ b/newamericadotorg/assets/react/report/index.js
@@ -319,6 +319,10 @@ class Routes extends Component {
             render={() => <Redirect to={results.url} />}
           />
           <Route
+            path={`/h_preview`}
+            render={this.reportRender}
+          />
+          <Route
             path="/:program/reports/:reportTitle/:sectionSlug?"
             render={this.reportRender}
           />
@@ -348,7 +352,19 @@ class APP extends Component {
   }
 
   render() {
-    let { reportId } = this.props;
+    let { reportId, preview, token, contentType } = this.props;
+
+    if (preview) {
+      return (
+        <Fetch
+          name={NAME}
+          endpoint={`preview`}
+          initialQuery={{'content_type': contentType, token: token}}
+          fetchOnMount={true}
+          component={Routes}
+        />
+      );
+    }
 
     if (window.initialState) return <Response name={NAME} component={Routes} />;
 

--- a/newamericadotorg/assets/react/report/index.js
+++ b/newamericadotorg/assets/react/report/index.js
@@ -54,7 +54,7 @@ const SinglePage = ({ report, dispatch, location }) => (
   </div>
 );
 
-const Landing = ({ report, dispatch, location, closeMenu }) => (
+const Landing = ({ report, dispatch, location, closeMenu, preview }) => (
   <div className={`report landing`}>
     <Heading report={report} />
 
@@ -80,7 +80,7 @@ const Landing = ({ report, dispatch, location, closeMenu }) => (
 
     <div className="container margin-80" id="contents">
       <h3 className="margin-top-0 margin-bottom-25">Contents</h3>
-      <ContentMenu report={report} closeMenu={closeMenu} />
+      <ContentMenu preview={preview} report={report} closeMenu={closeMenu} />
     </div>
 
     <div className="container margin-80" id="authors">
@@ -258,6 +258,7 @@ class Report extends Component {
           data-scroll-trigger-point="bottom"
         >
           <BottomNav
+            preview={this.props.preview}
             section={section}
             report={report}
             openMenu={this.openMenu}
@@ -274,6 +275,7 @@ class Report extends Component {
             report={report}
             closeMenu={this.closeMenu}
             showHome={true}
+            preview={this.props.preview}
           />
         </Overlay>
 
@@ -320,7 +322,15 @@ class Routes extends Component {
           />
           <Route
             path={`/h_preview`}
-            render={this.reportRender}
+            render={(props) => this.reportRender(Object.assign(props, {preview: true}))}
+          />
+          <Route
+            path="/preview/:program/:subprogram/reports/:reportTitle/:sectionSlug?"
+            render={(props) => this.reportRender(Object.assign(props, {preview: true}))}
+          />
+          <Route
+            path="/preview/:program/reports/:reportTitle/:sectionSlug?"
+            render={(props) => this.reportRender(Object.assign(props, {preview: true}))}
           />
           <Route
             path="/:program/reports/:reportTitle/:sectionSlug?"

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -249,3 +249,7 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'newamericadotorg.api.pagination.CustomPagination'
 }
+
+HEADLESS_PREVIEW_CLIENT_URLS = {
+    'default': 'http://localhost:8000/h_preview',
+}

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -252,4 +252,7 @@ REST_FRAMEWORK = {
 
 HEADLESS_PREVIEW_CLIENT_URLS = {
     'default': 'http://localhost:8000/h_preview',
+    'newamerica.org': 'https://www.newamerica.org:8000/h_preview',
+    'na-staging.herokuapp.com': 'https://na-staging.herokuapp.com:8000/h_preview',
+    'na-develop.herokuapp.com': 'https://na-develop.herokuapp.com:8000/h_preview',
 }

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -82,7 +82,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'django_filters',
-    'rest_framework'
+    'rest_framework',
+    'wagtail_headless_preview',
 ]
 
 MIDDLEWARE = [

--- a/newamericadotorg/templates/preview.html
+++ b/newamericadotorg/templates/preview.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block body_id %}na-preview{% endblock %}
+
+{% block header %}{% endblock %}
+
+{% block extra_scripts %}
+    <script>
+     window.initialState = {% if initial_state %}{{ initial_state|safe }}{% else %}null{% endif %};
+    </script>
+{% endblock %}
+
+{% block content %}
+    <main id="na-react__preview" data-preview="true"></main>
+{% endblock %}

--- a/newamericadotorg/urls.py
+++ b/newamericadotorg/urls.py
@@ -21,6 +21,7 @@ from rss_feed.feeds import GenericFeed, ContentFeed, AuthorFeed, ProgramFeed, Su
 import programs.views as program_views
 
 import newamericadotorg.redirects as redirects
+import newamericadotorg.views
 
 urlpatterns = [
     url(r'^django-admin/', admin.site.urls),
@@ -32,6 +33,7 @@ urlpatterns = [
     url(r'^images/', include(wagtailimages_urls)),
 
     url(r'^search/$', search_view, name='search'),
+    url(r'^h_preview/$', newamericadotorg.views.preview, name='headless_preview'),
 
     url(r'^feed/$', GenericFeed()),
     url(r'^feed/program/(?P<program>[a-zA-z\-]*)/$', ProgramFeed()),

--- a/newamericadotorg/views.py
+++ b/newamericadotorg/views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def preview(request, **kwargs):
+    return render(request, 'preview.html', context={})

--- a/report/models.py
+++ b/report/models.py
@@ -18,6 +18,7 @@ from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
+from wagtail_headless_preview.models import HeadlessPreviewMixin
 
 from home.models import AbstractHomeContentPage, Post
 from programs.models import AbstractContentPage
@@ -28,7 +29,7 @@ from .tasks import (
 )
 
 
-class Report(RoutablePageMixin, Post):
+class Report(HeadlessPreviewMixin, RoutablePageMixin, Post):
     """
     Report class that inherits from the abstract
     Post model and creates pages for Policy Papers.

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ django-multiselectfield==0.1.12
 newrelic==5.6.0.135
 gunicorn==20.0.4
 sentry-sdk==0.14.1
+wagtail-headless-preview==0.1.4
 
 # Development packages
 Faker==4.0.1


### PR DESCRIPTION
Fixes #1635 

So far:

1. Only applies to reports
2. Uses a hard-coded "localhost" URL. This is what the docs say to do, but it means it probably won't work outside of a local dev environment. There's probably a way around this, like setting up specific URLs for each of our environments, but it is not done yet.