### PR TITLE
Wagtail 2.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ boto3==1.12.5
 elasticsearch==5.5.3
 redis==3.4.1
 #See https://github.com/wagtail/wagtail-autocomplete
-wagtail-autocomplete==0.6
+wagtail-autocomplete==0.6.3
 #See https://pypi.org/project/django-multiselectfield/
 django-multiselectfield==0.1.12
 # Production packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.0.11
-Wagtail==2.12.4
+Wagtail==2.13
 
 # Packages that depend on Django version
 Celery==4.4.0


### PR DESCRIPTION
Fixes #1655 

There actually did not seem to be any other things we needed to change based on this wagtail update. The autocomplete fields on survey pages looked fine to me, but I bumped the version of `wagtail-autocomplete` to the latest patch level just in case.