### PR TITLE
Headless preview for program about pages

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -408,7 +408,7 @@ class ProgramSimplePage(AbstractSimplePage):
     class Meta:
         verbose_name = 'About Page'
 
-class ProgramAboutHomePage(ProgramSimplePage):
+class ProgramAboutHomePage(RedirectHeadlessPreviewMixin, ProgramSimplePage):
     parent_page_types = ['programs.Program', 'programs.Subprogram', 'programs.Project']
     subpage_types = [
         'home.ProgramAboutPage'

--- a/home/models.py
+++ b/home/models.py
@@ -427,7 +427,7 @@ class ProgramAboutHomePage(ProgramSimplePage):
 
         return context
 
-class ProgramAboutPage(ProgramSimplePage):
+class ProgramAboutPage(RedirectHeadlessPreviewMixin, ProgramSimplePage):
     parent_page_types = ['home.ProgramAboutHomePage']
     subpage_types = [
         'home.ProgramSimplePage'

--- a/newamericadotorg/api/meta/views.py
+++ b/newamericadotorg/api/meta/views.py
@@ -1,18 +1,19 @@
 from django.contrib.contenttypes.models import ContentType
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-
 from rest_framework import status
-from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from wagtail_headless_preview.models import PagePreview
 
-from home.models import HomePage, ProgramAboutPage, ProgramAboutHomePage
-from programs.models import Program
-
-from newamericadotorg.settings.context_processors import content_types
-from newamericadotorg.api.program.serializers import ProgramSerializer, SubscriptionSegmentSerializer, ProgramDetailSerializer, AboutPageSerializer
+from home.models import HomePage, ProgramAboutHomePage, ProgramAboutPage
+from newamericadotorg.api.program.serializers import (
+    AboutPageSerializer, ProgramDetailSerializer, ProgramSerializer,
+    SubscriptionSegmentSerializer,
+)
 from newamericadotorg.api.report.serializers import ReportDetailSerializer
+from newamericadotorg.settings.context_processors import content_types
+from programs.models import Program
 
 
 @method_decorator([cache_page(2*60)], name='get')

--- a/newamericadotorg/api/meta/views.py
+++ b/newamericadotorg/api/meta/views.py
@@ -92,6 +92,9 @@ class PreviewView(APIView):
             about_page_data = AboutPageSerializer(page_being_previewed).data
             about_page_data['subpages'] = AboutPageSerializer(ProgramAboutPage.objects.descendant_of(page_being_previewed).live().in_menu(), many=True).data
             program_data['about'] = about_page_data
+
+            # Extra data used used for establishing initial front-end route
+            program_data['__extra'] = 'about'
             return Response(program_data)
         elif content_type.model == 'programaboutpage':
             page_being_previewed = page_preview.as_page()
@@ -120,6 +123,8 @@ class PreviewView(APIView):
 
             program_data['about'] = about_page_data
 
+            # Extra data used used for establishing initial front-end route
+            program_data['__extra'] = f'about/{page_being_previewed.slug}'
             return Response(program_data)
         else:
             return Response(

--- a/newamericadotorg/assets/newamericadotorg.js
+++ b/newamericadotorg/assets/newamericadotorg.js
@@ -106,7 +106,7 @@ function importPageComponents() {
       if (urlParams.get("content_type") == "report.report") {
         element.setAttribute("id", "na-react__report"); // imitate the actual id used by the report page type
         import(/* webpackChunkName: "na-report-components" */ './react/components.report');
-      } else if (urlParams.get("content_type") == "home.programaboutpage") {
+      } else if (urlParams.get("content_type") == "home.programaboutpage" || urlParams.get("content_type") == "home.programabouthomepage" ) {
         let programContainer = document.getElementById("na-react__preview");
         programContainer.setAttribute("class", "program container--full-width");
 

--- a/newamericadotorg/assets/newamericadotorg.js
+++ b/newamericadotorg/assets/newamericadotorg.js
@@ -106,6 +106,22 @@ function importPageComponents() {
       if (urlParams.get("content_type") == "report.report") {
         element.setAttribute("id", "na-react__report"); // imitate the actual id used by the report page type
         import(/* webpackChunkName: "na-report-components" */ './react/components.report');
+      } else if (urlParams.get("content_type") == "home.programaboutpage") {
+        let programContainer = document.getElementById("na-react__preview");
+        programContainer.setAttribute("class", "program container--full-width");
+
+        // Recreate the inner program container element.
+        let inner = document.createElement("div");
+        inner.setAttribute("id", "na-react__program-page");
+        inner.dataset.token = urlParams.get("token");
+        inner.dataset.contentType = urlParams.get("content_type");
+        inner.dataset.preview = true;
+        inner.dataset.programId = "-1";
+        inner.dataset.programType = "program";
+        inner.dataset.programTitle = "Preview";
+        programContainer.appendChild(inner);
+
+        import(/* webpackChunkName: "na-program-components" */ './react/components.program');
       }
       break;
     default:

--- a/newamericadotorg/assets/react/program-page/components/About.js
+++ b/newamericadotorg/assets/react/program-page/components/About.js
@@ -54,9 +54,9 @@ export default class About extends Component {
   }
 
   render(){
-    let { about, program, root } = this.props;
+    let { about, program, root, preview } = this.props;
     let { subpages } = about;
-    
+
     return (
       <div className={`program__about margin-top-10 ${subpages.length > 0 ? 'with-menu' : ''}`}>
         <div className="row">
@@ -64,11 +64,11 @@ export default class About extends Component {
             <span>
               <div className="">
                 <h6 className="link margin-top-5 margin-bottom-15">
-                  <NavLink exact to={`${program.url}about/`}>About</NavLink>
+                  <NavLink exact to={preview ? `/${root}/about/` : `${program.url}about/`}>About</NavLink>
                 </h6>
               {subpages.map((p,i)=>(
                   <h6 key={i} className="link margin-top-0 margin-bottom-15">
-                    <NavLink to={p.url}>{p.title}</NavLink>
+                    <NavLink to={preview ? `/${root}/about/${p.slug}/` : p.url}>{p.title}</NavLink>
                   </h6>
               ))}
               </div>

--- a/newamericadotorg/assets/react/program-page/index.js
+++ b/newamericadotorg/assets/react/program-page/index.js
@@ -41,7 +41,7 @@ class ProgramPage extends Component {
   render(){
     let { response: { results }, programType, preview } = this.props;
     let root;
-    if(preview) root = `admin/pages/${results.id}/edit/preview`
+    if(preview) root = "h_preview"
     else root = programType == 'program' ? ':program' : ':program/:subprogram';
 
     return (
@@ -50,7 +50,7 @@ class ProgramPage extends Component {
             <Heading program={results} />
             <Route path={`/${root}/:subpage?`} render={(props)=>(<Nav {...props} program={results} root={root} preview={preview}/>)}/>
             <Route path={`/${root}/`} exact render={()=>(<StoryGrid program={results} loaded={this.state.loaded} story_grid={results.story_grid} programType={programType}/>)} />
-            {results.about && <Route path={`/${root}/about/`} render={()=>(<About program={results} about={results.about} root={root} />)} /> }
+            {results.about && <Route path={`/${root}/about/`} render={()=>(<About program={results} about={results.about} root={root} preview={preview} />)} /> }
             <Route path={`/${root}/our-people/`} render={(props)=>(<People programType={programType} {...props} program={results} /> )} />
             <Route path={`/${root}/events/`} render={(props)=>(<Events programType={programType} {...props} program={results} /> )} />
             <Route path={`/${root}/projects/`} render={(props)=>(<Subprograms {...props} program={results} /> )} />
@@ -144,10 +144,23 @@ class APP extends Component {
   }
 
   render() {
-    let { programId, programType, programTitle } = this.props;
+    let { programId, programType, programTitle, preview, token, contentType } = this.props;
     return (
       <GARouter>
         <Switch>
+          <Route
+            path="/h_preview"
+            render={() => (
+              <Fetch
+                name={NAME}
+                endpoint={`preview`}
+                initialQuery={{'content_type': contentType, token: token}}
+                fetchOnMount={true}
+                programType={programType}
+                component={ProgramPage}
+                preview={true}
+              />
+            )}/>
         <Route path={`/admin/pages/${programId}/edit/preview/`} render={(props)=>(
           <Response name={NAME}
             component={ProgramPage}

--- a/newamericadotorg/assets/react/program-page/index.js
+++ b/newamericadotorg/assets/react/program-page/index.js
@@ -44,6 +44,12 @@ class ProgramPage extends Component {
     if(preview) root = "h_preview"
     else root = programType == 'program' ? ':program' : ':program/:subprogram';
 
+    if (results['__extra'] && !window.location.pathname.includes("/about/")) {
+      return (
+        <Redirect to={`/${root}/${results["__extra"]}/`} />
+      )
+    }
+
     return (
       <div className="container">
           <div className="program__content">

--- a/newamericadotorg/views.py
+++ b/newamericadotorg/views.py
@@ -1,5 +1,7 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
 
+@login_required
 def preview(request, **kwargs):
     return render(request, 'preview.html', context={})


### PR DESCRIPTION
Fixes #1668 

This pull request adds headless preview functionality for pages of type `ProgramAboutPage` and `ProgramAboutHomePage`.