### PR TITLE
Update wagtail from 2.13 to 2.13.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.2.3
-Wagtail==2.13
+Wagtail==2.13.2
 
 # Packages that depend on Django version
 Celery==4.4.0


### PR DESCRIPTION
Fixes #1687 

Addresses security issue CVE-2021-32681.