### PR TITLE
1674 Fix full-bleed image spacing

### DIFF
--- a/newamericadotorg/assets/react/report/components/Heading.scss
+++ b/newamericadotorg/assets/react/report/components/Heading.scss
@@ -76,13 +76,8 @@
     flex-direction: column;
   }
 
-  .card__image__background {
-    padding-bottom: 48.461538461%;
-    position: static;
-
-    @include media-breakpoint-down(tablet) {
-      padding-bottom: 75% !important;
-    }
+  .card__image__background-image:last-child {    
+    margin-bottom: 1.75rem;
   }
 }
 


### PR DESCRIPTION
Now has margin below when it has no image credit
Also removed css that wasn't being used (bc the selector was wrong)


Compare one without a source: http://localhost:8000/education-policy/reports/lessons-from-the-illinois-media-mentor-project/
and one with a source (should be unchanged) http://localhost:8000/education-policy/reports/bets-job-strategy/

Fixes #1674