### PR TITLE
1665 surveys show up in epp publications page filters

### DIFF
--- a/newamericadotorg/api/helpers.py
+++ b/newamericadotorg/api/helpers.py
@@ -1,3 +1,4 @@
+from survey.models import SurveysHomePage
 from home.models import Post, HomePage, CustomImage
 from programs.models import Program, Subprogram, AbstractContentPage, PublicationsPage
 from event.models import ProgramEventsPage, AllEventsHomePage
@@ -61,6 +62,7 @@ def get_program_content_types(program):
 
     children = page.get_children().type(AbstractContentPage).not_type(PublicationsPage).not_type(ProgramPeoplePage)\
         .not_type(TopicHomePage).not_type(ProgramEventsPage).not_type(AllEventsHomePage).not_type(ProgramPolicyPapersPage)\
+        .not_type(SurveysHomePage)\
         .live()
 
     content_types = []

--- a/newamericadotorg/assets/react/components/Publications.js
+++ b/newamericadotorg/assets/react/components/Publications.js
@@ -29,7 +29,7 @@ export class PublicationsList extends Component {
     let { response, fetchAndAppend, card_type } = this.props;
     let { results, isFetching, hasNext } = response;
     if(results.length===0 && !isFetching){
-      if(card_type = 'future_events'){
+      if(card_type == 'future_events'){
         return (
           <div className="margin-top-60 centered">
             <h6 className="inline">No upcoming events. </h6>


### PR DESCRIPTION
First commit:
http://localhost:8000/education-policy/publications/ won't show HigherEd Public Opinion Hub in the content type filter.

Second commit:
"HigherEd Public Opinion Hub" still shows in the Projects filter but that seems like a bigger issue, beyond the purview of this ticket. However, http://localhost:8000/education-policy/publications/?projectId=28870 will at least say "No results found" instead of "No upcoming events" lol

Closes #1665 