### PR TITLE
Re-adding css for report images

### DIFF
--- a/newamericadotorg/assets/react/report/components/Heading.scss
+++ b/newamericadotorg/assets/react/report/components/Heading.scss
@@ -74,11 +74,20 @@
     max-width: none;
     display: flex;
     flex-direction: column;
+
+    .card__image__background-image:last-child {    
+      margin-bottom: 1.75rem;
+    }
   }
 
-  .card__image__background-image:last-child {    
-    margin-bottom: 1.75rem;
-  }
+  .card__image__background {
+      padding-bottom: 48.461538461%;
+      position: static;
+  
+      @include media-breakpoint-down(tablet) {
+        padding-bottom: 75% !important;
+      }
+    }
 }
 
 .card__image__background-image {

--- a/newamericadotorg/assets/react/report/components/Heading.scss
+++ b/newamericadotorg/assets/react/report/components/Heading.scss
@@ -81,13 +81,13 @@
   }
 
   .card__image__background {
-      padding-bottom: 48.461538461%;
-      position: static;
-  
-      @include media-breakpoint-down(tablet) {
-        padding-bottom: 75% !important;
-      }
+    padding-bottom: 48.461538461%;
+    position: static;
+
+    @include media-breakpoint-down(tablet) {
+      padding-bottom: 75% !important;
     }
+  }
 }
 
 .card__image__background-image {


### PR DESCRIPTION
Follow up to https://github.com/newamericafoundation/newamerica-cms/pull/1689

Turns out that css _was_ being used, by reports without a full-bleed image, e.g. http://localhost:8000/international-security/reports/world-drones/

And I hadn't nested the css I did add 🙃 