### PR TITLE
Surveys in publication search

### DIFF
--- a/newamericadotorg/api/search/tests.py
+++ b/newamericadotorg/api/search/tests.py
@@ -457,6 +457,14 @@ class SearchOtherPagesAPITests(APITestCase):
             topic_data={'title': 'Octopus'}
         )
 
+        cls.surveys = PostFactory.create_program_content(
+            1,
+            program=cls.program,
+            content_page_type=survey.models.SurveysHomePage,
+            post_type=survey.models.Survey,
+            post_data={'title': 'Octopus'},
+        )
+
     def setUp(self):
         management.call_command('update_index', stdout=StringIO(), chunk_size=50)
 
@@ -466,4 +474,5 @@ class SearchOtherPagesAPITests(APITestCase):
         ids = set(r['id'] for r in result['results'])
 
         self.assertNotIn('error', result)
-        self.assertEquals(result['count'], 3)
+        self.assertEquals(result['count'], 4)
+        self.assertIn(self.surveys[0].pk, ids)

--- a/newamericadotorg/api/search/tests.py
+++ b/newamericadotorg/api/search/tests.py
@@ -11,6 +11,7 @@ from wagtail.search.backends import get_search_backend
 
 from test_factories import PostFactory
 
+import survey.models
 from blog.models import ProgramBlogPostsPage, BlogPost
 from event.models import Event, ProgramEventsPage
 
@@ -363,6 +364,7 @@ class SearchPastEventsAPITests(APITestCase):
         )
         cls.past_party_id = past_party[0].pk
         cls.post_ids = {post.pk for post in posts}
+        cls.program = program
 
     def setUp(self):
         management.call_command('update_index', stdout=StringIO(), chunk_size=50)
@@ -376,6 +378,21 @@ class SearchPastEventsAPITests(APITestCase):
         self.assertEquals(result['count'], 3)
         self.assertIn(self.past_party_id, returned_ids)
         self.assertTrue(self.post_ids <= returned_ids)
+
+    def test_excludes_surveys(self):
+        surveys = PostFactory.create_program_content(
+            5,
+            program=self.program,
+            content_page_type=survey.models.SurveysHomePage,
+            post_type=survey.models.Survey,
+            post_data={'title': 'Party'}
+        )
+        url = '/api/search/pubs_and_past_events/?query=party'
+        result = self.client.get(url).json()
+        ids = set(r['id'] for r in result['results'])
+
+        self.assertNotIn('error', result)
+        self.assertEquals(result['count'], 3)
 
 
 @unittest.skipUnless(TEST_ELASTICSEARCH, "Elasticsearch tests not enabled")

--- a/newamericadotorg/api/search/views.py
+++ b/newamericadotorg/api/search/views.py
@@ -13,7 +13,19 @@ from wagtail.search.models import Query
 import survey.models
 from .serializers import SearchSerializer
 from newamericadotorg.api.event.serializers import EventSerializer
+from article.models import Article
+from book.models import Book
+from brief.models import Brief
+from press_release.models import PressRelease
 from event.models import Event
+from weekly.models import WeeklyArticle
+from blog.models import BlogPost
+from the_thread.models import ThreadArticle
+from podcast.models import Podcast
+from quoted.models import Quoted
+from policy_paper.models import PolicyPaper
+from in_depth.models import InDepthProject
+from other_content.models import OtherPost
 from programs.models import Program, Subprogram
 from home.models import Post, RedirectPage
 from person.models import Person
@@ -115,13 +127,27 @@ class SearchOtherPages(ListAPIView):
             .public()
             .not_type(
                 (
+                    # Pages included in other searches
                     Person,
                     Program,
                     Subprogram,
-                    Post,
                     Event,
                     SubscriptionSegment,
                     RedirectPage,
+                    # Exclude all Post subclasses except "Survey"
+                    Article,
+                    Book,
+                    Brief,
+                    PressRelease,
+                    Event,
+                    WeeklyArticle,
+                    BlogPost,
+                    ThreadArticle,
+                    Podcast,
+                    Quoted,
+                    PolicyPaper,
+                    InDepthProject,
+                    OtherPost,
                     # Non-informational pages for survey filtering.
                     survey.models.SurveyOrganization,
                     survey.models.DemographicKey,

--- a/newamericadotorg/api/search/views.py
+++ b/newamericadotorg/api/search/views.py
@@ -176,6 +176,7 @@ class SearchPublicationsAndPastEvents(ListAPIView):
             Post.objects.live()
             .public()
             .type((Post, Event))
+            .not_type(survey.models.Survey)
             .filter(date__lt=today)
             .descendant_of(site_for_request.root_page, inclusive=True)
         )


### PR DESCRIPTION
Fixes #1675 

This pull request removes surveys from the Publications and Other Events search results section and puts them into the Other Pages section.