### PR TITLE
Exclude reports from the other pages search

### DIFF
--- a/newamericadotorg/api/search/views.py
+++ b/newamericadotorg/api/search/views.py
@@ -30,6 +30,7 @@ from programs.models import Program, Subprogram
 from home.models import Post, RedirectPage
 from person.models import Person
 from subscribe.models import SubscriptionSegment
+from report.models import Report
 
 
 def exclude_invisible_pages(request, pages):
@@ -149,6 +150,7 @@ class SearchOtherPages(ListAPIView):
                     PolicyPaper,
                     InDepthProject,
                     OtherPost,
+                    Report,
                     # Non-informational pages for survey filtering.
                     survey.models.SurveyOrganization,
                     survey.models.DemographicKey,


### PR DESCRIPTION
This pull request adds Reports to the list of page types excluded from the Other Pages search bucket. To be honest I'm not sure why this was not originally there, but it seems that it was not! It's there now, though.