### PR TITLE
Bump django from 3.2.3 to 3.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.3
+Django==3.2.5
 Wagtail==2.13.4
 
 # Packages that depend on Django version


### PR DESCRIPTION
Upgrades to the latest version of the 3.2 branch of Django. Includes the security fixes mentioned in #1720 