### PR TITLE
Add security headers for X-XSS-Protection and X-Content-Type-Options

### DIFF
--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -145,6 +145,14 @@ DATABASES = {
 }
 
 
+# Django HTTP settings
+
+# X-XSS-Protection
+SECURE_BROWSER_XSS_FILTER = True
+# X-Content-Type-Options
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 


### PR DESCRIPTION
Refs #1238

This PR adds explicit settings for two security headers we should be using `X-XSS-Protection` and `X-Content-Type-Options`.