### PR TITLE
Add sentry environment

### DIFF
--- a/newamericadotorg/settings/production.py
+++ b/newamericadotorg/settings/production.py
@@ -96,6 +96,7 @@ if 'SENTRY_DSN' in os.environ:
     sentry_sdk.init(
         dsn=os.environ['SENTRY_DSN'],
         integrations=[DjangoIntegration()],
+        environment=os.environ['SENTRY_ENVIRONMENT'],
 
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.


### PR DESCRIPTION
Looking here: https://docs.sentry.io/platforms/python/guides/celery/configuration/environments/

I think we just didn't have environments set up in the code, even though we already have the variable in Heroku.