### PR TITLE
More CSP Updates

### DIFF
--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -285,14 +285,14 @@ CSP_SCRIPT_SRC = (
     "'unsafe-eval'",  # Needed for funding disclosures JS
     "'unsafe-inline'",  # Needed for Wagtail admin pages
     'https://www.googletagmanager.com',
-    'static.ads-twitter.com',
+    'https://static.ads-twitter.com',
     'https://analytics.twitter.com',
     'https://www.google.com/recaptcha/',
     'https://www.gstatic.com/recaptcha/',
     'https://na-data-projects.s3.amazonaws.com',
-    'www.youtube.com',
+    'https://www.youtube.com',
     'https://cdnjs.cloudflare.com',
-    'load.sumo.com',
+    'https://load.sumo.com',
     'https://www.google-analytics.com',
     'https://js-agent.newrelic.com',
     'https://bam.nr-data.net',
@@ -300,7 +300,7 @@ CSP_SCRIPT_SRC = (
 CSP_STYLE_SRC = (
     "'self'",
     "'unsafe-inline'",  # Needed for dynamic inline styles
-    'fonts.googleapis.com',
+    'https://fonts.googleapis.com',
 )
 CSP_IMG_SRC = (
     "'self'",
@@ -308,7 +308,7 @@ CSP_IMG_SRC = (
     'https://d1y8sb8igg2f8e.cloudfront.net',
     'data:',  # Funding disclosures widget makes use of data svgs
     "https://*.gravatar.com",
-    't.co',
+    'https://t.co',
     'https://www.google-analytics.com',
     'https://micro-cdn.sumo.com',
     'https://analytics.twitter.com',
@@ -317,7 +317,7 @@ CSP_IMG_SRC = (
 )
 CSP_FRAME_SRC = (
     "'self'",
-    'datawrapper.dwcdn.net',
+    'https://datawrapper.dwcdn.net',
     'https://www.google.com',
     # Embeds
     'https://www.youtube.com',  # YouTube
@@ -341,7 +341,7 @@ CSP_CONNECT_SRC = (
 CSP_FONT_SRC = (
     "'self'",
     'https://d3fvh0lm0eshry.cloudfront.net',
-    'fonts.gstatic.com',
+    'https://fonts.gstatic.com',
 )
 
 CSP_REPORT_URI = os.environ.get('CSP_REPORT_URI')

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -330,8 +330,6 @@ CSP_FRAME_SRC = (
     'https://art19.com',
     'https://renderer.apester.com',
 )
-CSP_OBJECT_SRC = ("'self'")
-CSP_MEDIA_SRC = ("'self'")
 CSP_CONNECT_SRC = (
     "'self'",
     'https://na-data-sheetsstorm.s3.us-west-2.amazonaws.com',

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -315,7 +315,8 @@ CSP_IMG_SRC = (
     'https://micro-cdn.sumo.com',
     'https://analytics.twitter.com',
     'https://www.googletagmanager.com',
-    'https://s3-us-west-2.amazonaws.com/na-data-projects'
+    'https://s3-us-west-2.amazonaws.com/na-data-projects',
+    'https://api.mapbox.com',
 )
 CSP_FRAME_SRC = (
     "'self'",
@@ -327,11 +328,13 @@ CSP_FRAME_SRC = (
     'https://w.soundcloud.com',
     'https://airtable.com',
     'https://art19.com',
+    'https://renderer.apester.com',
 )
 CSP_OBJECT_SRC = ("'self'")
 CSP_MEDIA_SRC = ("'self'")
 CSP_CONNECT_SRC = (
     "'self'",
+    'https://na-data-sheetsstorm.s3.us-west-2.amazonaws.com',
     "https://na-data-projects.s3.amazonaws.com",
     "https://releases.wagtail.io",
     'https://www.google-analytics.com',

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -284,6 +284,7 @@ CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-eval'",  # Needed for funding disclosures JS
     "'unsafe-inline'",  # Needed for Wagtail admin pages
+    'https://*.newamerica.org',
     'https://www.googletagmanager.com',
     'https://static.ads-twitter.com',
     'https://analytics.twitter.com',
@@ -304,6 +305,7 @@ CSP_STYLE_SRC = (
 )
 CSP_IMG_SRC = (
     "'self'",
+    'https://*.newamerica.org',
     'https://d3fvh0lm0eshry.cloudfront.net',
     'https://d1y8sb8igg2f8e.cloudfront.net',
     'data:',  # Funding disclosures widget makes use of data svgs
@@ -317,6 +319,7 @@ CSP_IMG_SRC = (
 )
 CSP_FRAME_SRC = (
     "'self'",
+    'https://*.newamerica.org',
     'https://datawrapper.dwcdn.net',
     'https://www.google.com',
     # Embeds


### PR DESCRIPTION
Refs #1746

1. Adds "https" wherever there was a protocol missing.
2. Adds additional allowed domains based on sentry alerts
3. Adds "*.newamerica.org" to more directives (this is necessary)