### PR TITLE
Make "data project external script" behave list "dataviz src"

### DIFF
--- a/newamericadotorg/assets/react/report/components/Body.js
+++ b/newamericadotorg/assets/react/report/components/Body.js
@@ -73,29 +73,6 @@ class Body extends Component {
   loadScripts = () => {
     let { report, section } = this.props;
     newamericadotorg.renderDataViz();
-    if (!this.el) return;
-    if (
-      report.data_project_external_script &&
-      document.querySelectorAll('.dataviz-project').length
-    ) {
-      const dataScript = document.createElement('script');
-
-      dataScript.src = `https://na-data-projects.s3.amazonaws.com/projects/${
-        report.data_project_external_script
-      }`;
-      dataScript.async = true;
-
-      this.el.appendChild(dataScript);
-    }
-    let scripts = section.body.match(/<script.*?src="(.*?)"/);
-    if (scripts) {
-      const script = document.createElement('script');
-
-      script.src = scripts[1];
-      script.async = true;
-
-      this.el.appendChild(script);
-    }
   };
 
   componentDidMount() {

--- a/report/templates/report/report.html
+++ b/report/templates/report/report.html
@@ -17,6 +17,9 @@
   {% if page.dataviz_src %}
     <script type="text/javascript" src="{{page.dataviz_src}}"></script>
   {% endif %}
+  {% if page.data_project_external_script %}
+      <script type="text/javascript" src="https://na-data-projects.s3.amazonaws.com/projects/{{ page.data_project_external_script }}" async=""></script>
+  {% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Reports with a defined "data project external script" field load this script by manipulating the DOM to add a `<script>` tag from within the JS of the report component.  Reports with a defined "dataviz src" field simply render the correct script tag from within the HTML template.

This change makes the former behave more like the latter in terms of the `<script>` tag.