### PR TITLE
Ensure structures we want as JSON are JSON-compatible

### DIFF
--- a/newamericadotorg/blocks.py
+++ b/newamericadotorg/blocks.py
@@ -404,7 +404,7 @@ class TimelineBlock(blocks.StructBlock):
                 "splitList": getJSCompatibleList(
                     value["major_timeline_splits"], True, False
                 ),
-                "categoryList": value["event_categories"],
+                "categoryList": list(value["event_categories"]),
             }
         )
         return context


### PR DESCRIPTION
Here I'm converting wagtail's internal `ListItem` type becomes a plain old python list before attempting to convert it to JSON.

Fixes this error: https://new-america.sentry.io/issues/4208195892/?environment=production&project=2985675&query=is%3Aunresolved&stream_index=0