### PR TITLE
Remove `ssl_cert_reqs` argument for local development

### DIFF
--- a/newamericadotorg/settings/dev.py
+++ b/newamericadotorg/settings/dev.py
@@ -27,10 +27,7 @@ if REDIS_URL:
             'LOCATION': REDIS_URL,
             'OPTIONS': {
                 'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-                'CONNECTION_POOL_KWARGS': {
-                    'ssl_cert_reqs': None,
-                },
-            }
+            },
         }
     }
 else:


### PR DESCRIPTION
This option is not supported for non-SSL redis connections.