### PR TITLE
Remove undo redo features

### DIFF
--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -11,8 +11,11 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-import dj_database_url
 import os
+
+import dj_database_url
+from PIL import ImageFile
+
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 
@@ -211,7 +214,10 @@ if os.getenv("BASIC_AUTH_ENABLED", "false").lower().strip() == "true":
 
     # This is the list of network IP addresses that are allowed in without
     # basic authentication check.
-    BASIC_AUTH_WHITELISTED_IP_NETWORKS = os.getenv("BASIC_AUTH_WHITELISTED_IP_NETWORKS", "").split(",")
+    BASIC_AUTH_WHITELISTED_IP_NETWORKS = os.getenv(
+        "BASIC_AUTH_WHITELISTED_IP_NETWORKS",
+        "",
+    ).split(",")
 
     # This is the list of hosts that website can be accessed without basic auth
     # check. This may be useful to e.g. white-list "llamasavers.com" but not
@@ -254,7 +260,6 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
     }
 }
 
-from PIL import ImageFile
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 REST_FRAMEWORK = {

--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -249,8 +249,6 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
                 'link',
                 'document-link',
                 'image',
-                'undo',
-                'redo',
             ]
         }
     }


### PR DESCRIPTION
"Undo" and "redo" are not [valid features for wagtail rich text editors](https://docs.wagtail.org/en/v4.1.6/advanced_topics/customisation/page_editing_interface.html#limiting-features-in-a-rich-text-field) (maybe at one time they were?) and it's causing this warning whenever the site loads:

```
/usr/local/lib/python3.10/site-packages/wagtail/admin/rich_text/editors/draftail/__init__.py:38: RuntimeWarning: Draftail received an unknown feature 'undo'.
  warnings.warn(
/usr/local/lib/python3.10/site-packages/wagtail/admin/rich_text/editors/draftail/__init__.py:38: RuntimeWarning: Draftail received an unknown feature 'redo'.
  warnings.warn(
```

This pull request removes them and the warnings no longer appear.