### PR TITLE
Limit width of featured sections on report landing

### DIFF
--- a/newamericadotorg/assets/react/report/components/FeaturedSections.scss
+++ b/newamericadotorg/assets/react/report/components/FeaturedSections.scss
@@ -29,6 +29,7 @@
     padding-right: 15px;
     margin-left: -15px;
     margin-right: -15px;
+    max-width: 100vw;
 
     .col-12 {
       display: inline-block;


### PR DESCRIPTION
Fixes a bug with the featured links  section being wider than the page such that the page content was going off the edge.