### PR TITLE
Add management command to tag posts into a given program

### DIFF
--- a/home/management/commands/retag_program_posts.py
+++ b/home/management/commands/retag_program_posts.py
@@ -9,23 +9,28 @@ from home.models import (
     PostTopicRelationship,
 )
 from issue.models import IssueOrTopic
+from person.models import (
+    PersonProgramRelationship,
+    PersonSubprogramRelationship,
+    PersonTopicRelationship,
+)
 from programs.models import Program, Subprogram
 
 
 class Command(BaseCommand):
-    help = "For all posts under a given Program/Subprogram/Topic, remove the tag for a second Program, and run the save method."
+    help = "Update the tagging on posts, people, and subpages from a given Program/Subprogram/Topic to a different Program."
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--parent",
-            help="The ID of a parent Program, Subprogram, or Topic in which to find child posts",
+            "--to",
+            help="The ID of a Program to which to re-tag people, posts, and pages.",
             required=True,
             type=int,
         )
 
         parser.add_argument(
-            "--remove",
-            help="The ID of a Program to remove from the posts",
+            "--from",
+            help="The ID of a Program, Subprogram, or Issue to untag people, pages, and posts from.",
             required=True,
             type=int,
         )
@@ -51,67 +56,137 @@ class Command(BaseCommand):
         )
 
     def show_page(self, page):
-        return f'{page.title} (id={page.pk}, type={page.page_type_display_name})'
+        return f"{page.title} (id={page.pk}, type={page.page_type_display_name})"
 
     def display_plan(self):
-        parent_page = self.parent
-        self.stdout.write(f"Found {len(self.posts_to_modify)} posts descended from {self.show_page(parent_page)}.\n- These posts will be saved.")
-        self.stdout.write(f"\nFound {len(self.tags_to_remove)} of these posts tagged with {self.show_page(self.page_to_untag)}.\n- These tags will be removed.")
+        self.stdout.write(
+            f"Found {len(self.posts_to_modify)} posts descended from {self.show_page(self.destination)}.\n- These posts will be saved."
+        )
+        self.stdout.write(
+            f"\nFound {len(self.post_tags_to_remove)} posts tagged with {self.show_page(self.page_to_untag)}.\n- These tags will be updated to refer to {self.show_page(self.destination)}.\n- The relationship of these posts to {self.show_page(self.page_to_untag)} will be removed."
+        )
+        self.stdout.write(
+            f"\nFound {len(self.person_tags_to_remove)} people tagged with {self.show_page(self.page_to_untag)}.\n- These people will be updated to belong to {self.show_page(self.destination)}.\n- The relationship of these people to {self.show_page(self.page_to_untag)} will be removed."
+        )
 
     def execute_plan(self):
         for post in self.posts_to_modify:
             post.save()
 
-        for tag in self.tags_to_remove:
-            self.stdout.write(f'Deleting {tag!r}')
+        for tag in self.post_tags_to_remove:
+            self.stdout.write(f"Deleting {tag!r}")
             tag.delete()
+        post_rs = PostProgramRelationship.objects.bulk_create(self.post_tags_to_create)
+        self.stdout.write(f"Post program relationships created: {len(post_rs)}.")
+
+        for tag in self.person_tags_to_remove:
+            self.stdout.write(f"Deleting {tag!r}")
+            tag.delete()
+        person_rs = PersonProgramRelationship.objects.bulk_create(
+            self.person_tags_to_create
+        )
+        self.stdout.write(f"Person program relationships created: {len(person_rs)}.")
 
     @transaction.atomic
     def handle(self, **options):
-        parent_pk = options["parent"]
+        from_pk = options["from"]
+        to_pk = options["to"]
 
         try:
-            self.parent = Page.objects.get(pk=parent_pk)
+            self.destination = Page.objects.get(pk=to_pk).specific
         except Page.DoesNotExist:
-            self.stdout.write(f'Page with ID {parent_pk!r} does not exist. Exiting.')
+            self.stdout.write(f"Page with ID {to_pk!r} does not exist. Exiting.")
             return
 
-        self.posts_to_modify = Post.objects.descendant_of(self.parent)
-        posts_to_modify_ids = self.posts_to_modify.values_list("pk", flat=True)
-        remove_pk = options["remove"]
+        self.posts_to_modify = Post.objects.descendant_of(self.destination)
+        self.posts_to_modify.values_list("pk", flat=True)
         try:
-            self.page_to_untag = Page.objects.get(pk=remove_pk).specific
+            self.page_to_untag = Page.objects.get(pk=from_pk).specific
         except Page.DoesNotExist:
-            self.stdout.write(f'Page with ID {remove_pk!r} does not exist. Exiting.')
+            self.stdout.write(f"Page with ID {from_pk!r} does not exist. Exiting.")
             return
 
         if isinstance(self.page_to_untag, Program):
-            self.tags_to_remove = PostProgramRelationship.objects.filter(
+            self.post_tags_to_remove = PostProgramRelationship.objects.filter(
                 program__pk=self.page_to_untag.pk,
-                post_id__in=posts_to_modify_ids,
             )
+            self.post_tags_to_create = [
+                PostProgramRelationship(
+                    program=self.destination,
+                    post=tag.post,
+                )
+                for tag in self.post_tags_to_remove
+            ]
+            self.person_tags_to_remove = PersonProgramRelationship.objects.filter(
+                program__pk=self.page_to_untag.pk,
+            )
+            self.person_tags_to_create = [
+                PersonProgramRelationship(
+                    program=self.destination,
+                    person=tag.person,
+                    group=tag.group,
+                    fellowship_position=tag.fellowship_position,
+                    sort_order=tag.sort_order,
+                )
+                for tag in self.person_tags_to_remove
+            ]
         elif isinstance(self.page_to_untag, Subprogram):
-            self.tags_to_remove = PostSubprogramRelationship.objects.filter(
+            self.post_tags_to_remove = PostSubprogramRelationship.objects.filter(
                 subprogram__pk=self.page_to_untag.pk,
-                post_id__in=posts_to_modify_ids,
             )
+            self.post_tags_to_create = [
+                PostProgramRelationship(
+                    program=self.destination,
+                    post=tag.post,
+                )
+                for tag in self.post_tags_to_remove
+            ]
+            self.person_tags_to_remove = PersonSubprogramRelationship.objects.filter(
+                subprogram__pk=self.page_to_untag.pk,
+            )
+            self.person_tags_to_create = [
+                PersonProgramRelationship(
+                    program=self.destination,
+                    person=tag.person,
+                    group=tag.group,
+                    fellowship_position=tag.fellowship_position,
+                    sort_order=tag.sort_order,
+                )
+                for tag in self.person_tags_to_remove
+            ]
         elif isinstance(self.page_to_untag, IssueOrTopic):
-            self.tags_to_remove = PostTopicRelationship.objects.filter(
+            self.post_tags_to_remove = PostTopicRelationship.objects.filter(
                 topic__pk=self.page_to_untag.pk,
-                post_id__in=posts_to_modify_ids,
             )
+            self.post_tags_to_create = [
+                PostProgramRelationship(
+                    program=self.destination,
+                    post=tag.post,
+                )
+                for tag in self.post_tags_to_remove
+            ]
+            self.person_tags_to_remove = PersonTopicRelationship.objects.filter(
+                topic__pk=self.page_to_untag.pk,
+            )
+            self.person_tags_to_create = [
+                PersonProgramRelationship(
+                    program=self.destination,
+                    person=tag.person,
+                )
+                for tag in self.person_tags_to_remove
+            ]
         else:
             self.stdout.write(
-                f"Page with id {remove_pk!r} is of type {self.page_to_untag.page_type_display_name!r}, not program, subprogram, or topic. Exiting."
+                f"Page with id {from_pk!r} is of type {self.page_to_untag.page_type_display_name!r}, not program, subprogram, or topic. Exiting."
             )
             return
 
         if options.get("commit", False):
             self.display_plan()
             self.execute_plan()
-            self.stdout.write('*** Database updated ***')
+            self.stdout.write("*** Database updated ***")
         else:
             self.display_plan()
             self.stdout.write(
-                "\n*** Database not updated, pass option --commit to retag posts. ***"
+                "\n*** Database not updated, pass option --commit to retag pages. ***"
             )

--- a/home/management/commands/retag_program_posts.py
+++ b/home/management/commands/retag_program_posts.py
@@ -1,0 +1,97 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from home.models import (
+    PostProgramRelationship,
+    PostSubprogramRelationship,
+    PostTopicRelationship,
+)
+from programs.models import Program
+
+
+class Command(BaseCommand):
+    help = "Tag all posts from one program, subprogram, or topic onto a different program, subprogram, or topic."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--from",
+            help="The slug of a Program, Subprogram, or Topic in which to find posts",
+            required=True,
+        )
+
+        parser.add_argument(
+            "--to",
+            help="The slug of a Program to which to add posts",
+            required=True,
+        )
+        parser.add_argument(
+            "--commit",
+            action="store_true",
+            help="Commit changes to the database",
+        )
+
+    def get_posts_for_program(self, slug):
+        return PostProgramRelationship.objects.filter(
+            program__slug=slug,
+        )
+
+    def get_posts_for_subprogram(self, slug):
+        return PostSubprogramRelationship.objects.filter(
+            subprogram__slug=slug,
+        )
+
+    def get_posts_for_topic(self, slug):
+        return PostTopicRelationship.objects.filter(
+            topic__slug=slug,
+        )
+
+    def display_plan(self, container_type, posts, slug):
+        self.stdout.write(f"Posts in {container_type} {slug}: {len(posts)}")
+
+    @transaction.atomic
+    def handle(self, **options):
+        from_slug = options["from"]
+
+        if post_rels := self.get_posts_for_program(from_slug):
+            self.display_plan("Program", post_rels, from_slug)
+        elif post_rels := self.get_posts_for_subprogram(from_slug):
+            self.display_plan("Subprogram", post_rels, from_slug)
+        elif post_rels := self.get_posts_for_topic(from_slug):
+            self.display_plan("IssueOrTopic", post_rels, from_slug)
+        else:
+            self.stdout.write(
+                f"No posts found for any program, subprogram, or topic with slug {from_slug!r}, aborting."
+            )
+            return
+
+        to_slug = options["to"]
+        try:
+            program = Program.objects.get(slug=to_slug)
+            self.stdout.write(f"Found program {program.title} with slug {to_slug!r}")
+        except Program.DoesNotExist:
+            self.stdout.write(f"No program found with slug {to_slug!r}, aborting.")
+            return
+
+        if options.get("commit", False):
+            total_created = 0
+            total_unchanged = 0
+
+            for post_rel in post_rels:
+                try:
+                    ppr, created = PostProgramRelationship.objects.get_or_create(
+                        program=program,
+                        post=post_rel.post,
+                    )
+                except PostProgramRelationship.MultipleObjectsReturned:
+                    created = False
+                if created:
+                    total_created += 1
+                else:
+                    total_unchanged += 1
+
+            self.stdout.write(f"Updated post count: {total_created}")
+            self.stdout.write(f"Posts already in program: {total_unchanged}")
+        else:
+            self.stdout.write(
+                "Database not updated, pass option --commit to retag posts."
+            )


### PR DESCRIPTION
Management command that takes two ID arguments (and an optional `commit` flag) and:

1. Looks for a page with the `to` ID and collects all pages with this page as an ancestor.  This collection is the set of "child" posts.
2. Looks for a program, subprogram, or issue/topic with the `from` slug.
3. If both are found, two actions are performed:
    1. The `save()` method is called on all the child posts of the `to` Program.
    2. All relationships between the `from` Program and _any_ Post or Person are removed, regardless of where that Post or Person is located in the page hierarchy. These relationships are replaced by relationships to the `to` Program.

By default, only provides counts but does not alter the database. Only make changes if `--commit` is given.  Otherwise, display information about what would be done.

Usage examples:

```
$ docker compose exec web ./manage.py retag_program_posts --to 1616 --from 1610
```

```
$ docker compose exec web ./manage.py retag_program_posts --to 1616 --from 1610 --commit
```


