### PR TITLE
Add background color to boxes in reports

### DIFF
--- a/newamericadotorg/assets/scss/pages/post/blocks/_box.scss
+++ b/newamericadotorg/assets/scss/pages/post/blocks/_box.scss
@@ -1,14 +1,18 @@
 .block-box{
   margin-top: 50px;
   margin-bottom: 50px;
-  border-top: 1px solid color(black);
-  border-bottom: 1px solid color(black);
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding: 40px;
+  background-color: #f5f5f5;
+
+  &__title {
+    text-transform: uppercase;
+    letter-spacing: .02em;
+    margin-top: 0;
+  }
 
   p, li, blockquote, a{
     font-family: $label-font-family !important;
-    font-size: 0.9375rem !important;
+    font-size: 1rem !important;
     line-height: 1.75rem !important;
   }
 
@@ -20,5 +24,20 @@
   blockquote {
     margin-top: 30px;
     margin-bottom: 30px;
+  }
+
+  > .block-paragraph:first-child .rich-text {
+    h1, h2, h3, h4, h5, h6, p {
+      &:first-child {
+        margin-top: 0;
+      }
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .block-datawrapper {
+    margin: -15px -20px -20px;
   }
 }

--- a/newamericadotorg/templates/blocks/box.html
+++ b/newamericadotorg/templates/blocks/box.html
@@ -1,8 +1,8 @@
 {% load wagtailcore_tags %}
 {% load cited_html %}
-<div class="block-box">
+<aside class="block-box">
   {% if value.title %}
-  <h5>→&nbsp;{{value.title}}</h5>
+  <h4 class="block-box__title">→&nbsp;{{value.title}}</h4>
   {% endif %}
   {% for block in value.body %}
       {% if block.block_type == 'paragraph' %}
@@ -17,4 +17,4 @@
         </div>
       {% endif %}
   {% endfor %}
-</div>
+</aside>

--- a/report/templates/report/pdf.html
+++ b/report/templates/report/pdf.html
@@ -137,7 +137,7 @@
               {% include './figure.html' with value=block.value %}
             {% elif block.block_type == 'box' %}
               <div class="block-box">
-                <h5>→&nbsp;{{block.value.title}}</h5>
+                {% if block.value.title %}<h5>→&nbsp;{{block.value.title}}</h5>{% endif %}
                 {% for box_block in block.value.body %}
                     {% if box_block.block_type == 'paragraph' %}
                       <div class="block-{{ box_block.block_type }}">

--- a/report/templates/report/pdf.html
+++ b/report/templates/report/pdf.html
@@ -145,6 +145,10 @@
                       </div>
                     {% elif box_block.block_type == 'inline_image' %}
                       {% include './figure.html' with value=box_block.value %}
+                    {% elif box_block.block_type == 'iframe' or box_block.block_type == 'datawrapper' %}
+                      {% if box_block.value.fallback_image %}
+                        {% include './figure_iframe.html' with value=box_block.value %}
+                      {% endif %}
                     {% else %}
                       <div class="block-{{ block.block_type }}">
                         {% include_block box_block %}

--- a/report/templates/report/pdf_style.html
+++ b/report/templates/report/pdf_style.html
@@ -256,6 +256,12 @@
       margin-bottom: 0;
     }
 
+    .block-box > *:first-child,
+    .block-box > *:first-child > *:first-child,
+    .block-box > *:first-child > *:first-child > *:first-child{
+      margin-top: 0;
+    }
+
     .block-box blockquote{
       font-family: 'Circular', 'SimHei';
     }

--- a/report/templates/report/pdf_style.html
+++ b/report/templates/report/pdf_style.html
@@ -237,9 +237,9 @@
 
     .block-box{
       margin: 35pt 0;
-      padding: 25pt 0;
-      border-top: 1pt solid #000;
-      border-bottom: 1pt solid #000;
+      padding: 25pt 25pt;
+      background-color: #f5f5f5;
+      box-decoration-break: clone;
     }
 
     .block-box h5{


### PR DESCRIPTION
Notes:
* This uses `box-decoration-break: clone` to make it visually nicer around page breaks.
* Does not change any styles on the HTML version of the report, yet