### PR TITLE
Make report title links visible when hovering

### DIFF
--- a/newamericadotorg/assets/react/report/components/TopNav.scss
+++ b/newamericadotorg/assets/react/report/components/TopNav.scss
@@ -54,6 +54,10 @@
     border-right: 1px solid #cdcdcd;
     padding-right: 15px;
 
+    a:hover {
+      color: color(turquoise);
+    }
+
     @include media-breakpoint(tablet){
       max-width: 500px;
       display: inline-block;


### PR DESCRIPTION
This pull request fixes the report top nav bar title hover behavior to not use a color that is the same as the background:

![image](https://github.com/newamericafoundation/newamerica-cms/assets/561931/6bd2a130-6cc1-4b0e-bcc0-888e2b823dba)
