### PR TITLE
Turn off CSP header

### DIFF
--- a/newamericadotorg/settings/base.py
+++ b/newamericadotorg/settings/base.py
@@ -106,7 +106,7 @@ MIDDLEWARE = [
     # Gzip/minify
     'django.middleware.gzip.GZipMiddleware',
     # Content security policy
-    'csp.middleware.CSPMiddleware',
+    # 'csp.middleware.CSPMiddleware',
 ]
 
 ROOT_URLCONF = 'newamericadotorg.urls'


### PR DESCRIPTION
Commenting out the middleware line keeps our in-progress configuration in the source code while disabling the actual header from being sent in responses.