### PR TITLE
Decrease size of rendered images in report pdfs

### DIFF
--- a/report/templates/report/figure.html
+++ b/report/templates/report/figure.html
@@ -1,4 +1,4 @@
-{% load utilities %}
+{% load utilities wagtailimages_tags %}
 
 <figure class="figure {{value.align}} {{value.width|temp_image_width_map}}">
   {% if value.figure_number or value.figure_title %}
@@ -12,7 +12,8 @@
     </div>
   {% endif %}
   <div class="figure__image">
-      <img src="{{ value.image.file.url }}" alt="{{ value.alt_text }}"/>
+      {% image value.image max-984x1500 as image %}
+      <img src="{{ image.url }}" alt="{{ value.alt_text }}"/>
   </div>
   {% if value.image.caption or value.image.source %}
     <figcaption>

--- a/report/templates/report/figure_iframe.html
+++ b/report/templates/report/figure_iframe.html
@@ -1,9 +1,10 @@
-{% load utilities %}
+{% load utilities wagtailimages_tags %}
 
 <figure class="figure {{value.fallback_image_align}} {{value.fallback_image_width|temp_image_width_map}}">
 
   <div class="figure__image">
-      <img src="{{ value.fallback_image.file.url }}" alt="{{ value.fallback_image_alt_text }}"/>
+      {% image value.fallback_image max-984x1500 as image %}
+      <img src="{{ image.url }}" alt="{{ value.fallback_image_alt_text }}"/>
   </div>
 
   {% if value.fallback_image.caption or value.fallback_image.source %}


### PR DESCRIPTION
In hopes of decreasing the effort required to render a pdf