### PR TITLE
Elastic Beanstalk Support

### DIFF
--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -3,3 +3,4 @@ packages:
     git: []
     libpq-devel: []
     libjpeg-turbo-devel: []
+    pango: []

--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -1,0 +1,5 @@
+packages:
+  yum:
+    git: []
+    postgresql13-devel: []
+    libjpeg-turbo-devel: []

--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -1,5 +1,5 @@
 packages:
   yum:
     git: []
-    postgresql13-devel: []
+    libpq-devel: []
     libjpeg-turbo-devel: []

--- a/.ebextensions/02_python.config
+++ b/.ebextensions/02_python.config
@@ -1,0 +1,13 @@
+option_settings:
+  "aws:elasticbeanstalk:application:environment":
+    DJANGO_SETTINGS_MODULE: "newamericadotorg.settings.eb_production"
+  "aws:elasticbeanstalk:container:python":
+    WSGIPath: newamericadotorg/wsgi.py
+    NumProcesses: 3
+    NumThreads: 20
+#  "aws:elasticbeanstalk:container:python:staticfiles":
+#    "/static/": "www/static/"
+# container_commands:
+#  01_migrate:
+#    command: "source /var/app/venv/*/bin/activate && python manage.py migrate --noinput"
+#    leader_only: true

--- a/.ebignore
+++ b/.ebignore
@@ -3,9 +3,35 @@
 *__pycache__/
 *.pyc
 *.DS_Store
+*.rdb
+fixture.json
+/.vagrant
 
 node_modules
 bower_components
 npm-debug.log
 *.env
 
+media/
+static/
+
+newamericadotorg/static/js/
+newamericadotorg/templates/style.css
+newamericadotorg/templates/styles.css
+newamericadotorg/templates/style.css.map
+newamericadotorg/templates/styles.css.map
+
+venv
+*.log
+
+*.csv
+*.crt
+*.key
+*.csr
+
+home/management/api/article_images/
+home/management/api/images/
+home/management/api/documents/
+report/utils/test.docx
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ report/utils/test.docx
 links.py
 
 .vscode
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,0 @@
-release: python manage.py migrate
-web: gunicorn newamericadotorg.wsgi --log-file -
-worker: celery worker --app=newamericadotorg.celery.app --loglevel=INFO

--- a/newamericadotorg/settings/eb_production.py
+++ b/newamericadotorg/settings/eb_production.py
@@ -28,6 +28,10 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # Will be changed to final host url
 ALLOWED_HOSTS = [
     '.newamerica.org',
+    # TODO: Eventually move to "dev" settings file.  The below is not
+    # a production domain.
+    'newamerica-cms-dev.us-east-1.elasticbeanstalk.com',
+    '44.223.168.94',
     # 'na-staging.herokuapp.com',
     # 'na-develop.herokuapp.com',
 ]

--- a/newamericadotorg/settings/eb_production.py
+++ b/newamericadotorg/settings/eb_production.py
@@ -2,6 +2,18 @@ import os
 
 from .base import *  # noqa: F403
 
+if 'RDS_DB_NAME' in os.environ:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': os.environ['RDS_DB_NAME'],
+            'USER': os.environ['RDS_USERNAME'],
+            'PASSWORD': os.environ['RDS_PASSWORD'],
+            'HOST': os.environ['RDS_HOSTNAME'],
+            'PORT': os.environ['RDS_PORT'],
+        }
+    }
+
 # Timezone settings
 TIME_ZONE = 'America/New_York'
 USE_TZ = True

--- a/newamericadotorg/settings/eb_production.py
+++ b/newamericadotorg/settings/eb_production.py
@@ -1,0 +1,162 @@
+import os
+
+from .base import *  # noqa: F403
+
+# Timezone settings
+TIME_ZONE = 'America/New_York'
+USE_TZ = True
+
+
+DEBUG = False
+
+APPEND_SLASH = True
+
+SECRET_KEY = os.getenv("SECRET_KEY")
+
+# Will be changed to final host url
+ALLOWED_HOSTS = [
+    '.newamerica.org',
+    # 'na-staging.herokuapp.com',
+    # 'na-develop.herokuapp.com',
+]
+
+SECURE_SSL_REDIRECT = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_HSTS_SECONDS = 63072000 # 2 years in seconds
+
+AWS_QUERYSTRING_AUTH = False
+AWS_IS_GZIPPED = True
+
+# s3 bucket settings
+AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
+
+# media file settings
+AWS_STORAGE_BUCKET_NAME = os.getenv('S3_BUCKET_NAME')
+CLOUDFRONT_DOMAIN = os.getenv('CLOUDFRONT_DOMAIN')
+CLOUDFRONT_ID = os.getenv('CLOUDFRONT_ID')
+AWS_S3_CUSTOM_DOMAIN = CLOUDFRONT_DOMAIN
+# AWS_S3_CUSTOM_DOMAIN = '%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
+
+MEDIA_URL = "https://%s/" % AWS_S3_CUSTOM_DOMAIN
+DEFAULT_FILE_STORAGE = 'custom_storages.MediaStorage'
+
+AWS_S3_OBJECT_PARAMETERS = {
+    'Expires': 'Thu, 31 Dec 2099 20:00:00 GMT',
+    'CacheControl': 'max-age=94608000',
+    'ACL': 'public-read',
+}
+STATIC_BUCKET_NAME = os.getenv('STATIC_S3_BUCKET_NAME', None)
+
+if STATIC_BUCKET_NAME is not None:
+    # Use S3 for static
+    STATICFILES_LOCATION = 'static'
+    STATICFILES_STORAGE = 'custom_storages.StaticStorage'
+    S3_STATIC_DOMAIN = '%s.s3.amazonaws.com' % STATIC_BUCKET_NAME
+    CLOUDFRONT_STATIC_URL = os.getenv('STATIC_URL')
+    #STATIC_URL = "https://%s/%s/" % (S3_STATIC_DOMAIN, STATICFILES_LOCATION)
+    STATIC_URL = "%s/%s/" % (CLOUDFRONT_STATIC_URL, STATICFILES_LOCATION)
+
+    # COMPRESS_URL = "https://%s/%s/" % (S3_STATIC_DOMAIN, STATICFILES_LOCATION)
+    # COMPRESS_STORAGE = STATICFILES_STORAGE
+
+else:
+    # Serve static from the web server using Whitenoise
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    STATIC_URL = '/static/'
+
+    STATICFILES_LOCATION = ''
+    S3_STATIC_DOMAIN = 'notusingthis.s3.amazonaws.com'
+    CLOUDFRONT_STATIC_URL = ''
+
+
+# Elastic Search setup
+es_url = os.getenv('SEARCHBOX_URL', "http://localhost:9200/")
+
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'search.backend',
+        'URLS': [es_url],
+        'INDEX': 'elasticsearch',
+        'TIMEOUT': 1500,
+    }
+}
+
+ANYMAIL = {
+    "MAILGUN_API_KEY": os.getenv('MAILGUN_API_KEY')
+}
+
+# Sentry
+
+if 'SENTRY_DSN' in os.environ:
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(
+        dsn=os.environ['SENTRY_DSN'],
+        integrations=[DjangoIntegration()],
+        environment=os.environ['SENTRY_ENVIRONMENT'],
+
+        # If you wish to associate users to errors (assuming you are using
+        # django.contrib.auth) you may enable sending PII data.
+        send_default_pii=True
+    )
+
+
+# Email backend configuration
+EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
+POSTMARK_SENDER = os.getenv("POSTMARK_SENDER")
+DEFAULT_FROM_EMAIL = POSTMARK_SENDER
+SERVER_EMAIL = POSTMARK_SENDER
+WAGTAILADMIN_NOTIFICATION_USE_HTML = True
+WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
+REDIS_URL = os.getenv(
+    'REDIS_TLS_URL',
+    os.getenv('REDIS_URL'),
+)
+
+WAGTAILFRONTENDCACHE = {
+    'cloudfront': {
+        'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudfrontBackend',
+        'DISTRIBUTION_ID': 'E3IZZ8NUJMHTIF',
+    },
+}
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': REDIS_URL,
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            'CONNECTION_POOL_KWARGS': {
+                'ssl_cert_reqs': None,
+            },
+        },
+    }
+}
+
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'newamericadotorg.api.pagination.CustomPagination',
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    )
+}
+
+# PDF Generator
+PDF_GENERATOR_URL = os.getenv('PDF_GENERATOR_URL')
+
+try:
+    from .local import *  # noqa: F403
+except ImportError:
+    pass
+
+# Wagtail settings
+
+# Base URL to use when referring to full URLs within the Wagtail admin backend -
+# e.g. in notification emails. Don't include '/admin' or a trailing slash
+WAGTAILADMIN_BASE_URL = os.getenv('BASE_URL', None)
+
+if WAGTAILADMIN_BASE_URL is None:
+    WAGTAILADMIN_BASE_URL = 'https://www.newamerica.org'

--- a/newamericadotorg/settings/eb_production.py
+++ b/newamericadotorg/settings/eb_production.py
@@ -87,14 +87,15 @@ else:
 # Elastic Search setup
 es_url = os.getenv('SEARCHBOX_URL', "http://localhost:9200/")
 
-WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'search.backend',
-        'URLS': [es_url],
-        'INDEX': 'elasticsearch',
-        'TIMEOUT': 1500,
+if es_url:
+    WAGTAILSEARCH_BACKENDS = {
+        'default': {
+            'BACKEND': 'search.backend',
+            'URLS': [es_url],
+            'INDEX': 'elasticsearch',
+            'TIMEOUT': 1500,
+        }
     }
-}
 
 ANYMAIL = {
     "MAILGUN_API_KEY": os.getenv('MAILGUN_API_KEY')
@@ -129,25 +130,32 @@ REDIS_URL = os.getenv(
     os.getenv('REDIS_URL'),
 )
 
-WAGTAILFRONTENDCACHE = {
-    'cloudfront': {
-        'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudfrontBackend',
-        'DISTRIBUTION_ID': 'E3IZZ8NUJMHTIF',
-    },
-}
+# WAGTAILFRONTENDCACHE = {
+#     'cloudfront': {
+#         'BACKEND': 'wagtail.contrib.frontend_cache.backends.CloudfrontBackend',
+#         'DISTRIBUTION_ID': 'E3IZZ8NUJMHTIF',
+#     },
+# }
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': REDIS_URL,
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-            'CONNECTION_POOL_KWARGS': {
-                'ssl_cert_reqs': None,
+if REDIS_URL:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': REDIS_URL,
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+                'CONNECTION_POOL_KWARGS': {
+                    'ssl_cert_reqs': None,
+                },
             },
-        },
+        }
     }
-}
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache'
+        }
+    }
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'newamericadotorg.api.pagination.CustomPagination',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # Django related
     'Django >= 3.2.6, < 4',
     'Wagtail >= 5.2.2, < 5.3',
-    'Celery >= 4.4, < 5.0',
+    'Celery >= 5.4, < 6.0',
     'dj-database-url >= 1.3.0, < 2',
     'django-cors-headers >= 3.13.0, < 4',
     'django-storages >= 1.13, < 2',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amqp==2.6.1
+amqp==5.2.0
     # via kombu
 anyascii==0.3.2
     # via wagtail
@@ -6,7 +6,7 @@ asgiref==3.6.0
     # via django
 beautifulsoup4==4.9.3
     # via wagtail
-billiard==3.6.4.0
+billiard==4.2.0
     # via celery
 boto3==1.26.114
     # via newamerica-cms (pyproject.toml)
@@ -20,7 +20,7 @@ cairocffi==1.5.0
     #   weasyprint
 cairosvg==2.7.0
     # via weasyprint
-celery==4.4.7
+celery==5.4.0
     # via newamerica-cms (pyproject.toml)
 certifi==2022.12.7
     # via
@@ -32,6 +32,18 @@ cffi==1.15.1
     #   weasyprint
 charset-normalizer==3.1.0
     # via requests
+click==8.1.7
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
 createsend==7.0.0
     # via newamerica-cms (pyproject.toml)
 cssselect2==0.7.0
@@ -117,7 +129,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-kombu==4.6.11
+kombu==5.3.7
     # via celery
 l18n==2021.3
     # via wagtail
@@ -132,6 +144,8 @@ pillow==9.5.0
     #   wagtail
 pillow-heif==0.14.0
     # via willow
+prompt-toolkit==3.0.43
+    # via click-repl
 psycopg2==2.9.6
     # via newamerica-cms (pyproject.toml)
 pycparser==2.21
@@ -139,12 +153,13 @@ pycparser==2.21
 pyphen==0.14.0
     # via weasyprint
 python-dateutil==2.8.2
-    # via botocore
+    # via
+    #   botocore
+    #   celery
 python-docx==0.8.11
     # via newamerica-cms (pyproject.toml)
 pytz==2023.3
     # via
-    #   celery
     #   django
     #   django-modelcluster
     #   djangorestframework
@@ -184,16 +199,19 @@ tinycss2==1.2.1
     #   weasyprint
 typing-extensions==4.5.0
     # via dj-database-url
+tzdata==2024.1
+    # via celery
 urllib3==1.26.15
     # via
     #   botocore
     #   elasticsearch
     #   requests
     #   sentry-sdk
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
 wagtail==5.2.2
     # via
     #   newamerica-cms (pyproject.toml)
@@ -205,6 +223,8 @@ wagtail-headless-preview==0.7.0
     # via newamerica-cms (pyproject.toml)
 wand==0.6.11
     # via newamerica-cms (pyproject.toml)
+wcwidth==0.2.13
+    # via prompt-toolkit
 weasyprint==51
     # via newamerica-cms (pyproject.toml)
 webencodings==0.5.1
@@ -215,7 +235,9 @@ webencodings==0.5.1
 whitenoise==6.4.0
     # via newamerica-cms (pyproject.toml)
 willow[heif]==1.6.2
-    # via wagtail
+    # via
+    #   wagtail
+    #   willow
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==67.6.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,4 +1,4 @@
-amqp==2.6.1
+amqp==5.2.0
     # via kombu
 anyascii==0.3.2
     # via wagtail
@@ -6,7 +6,7 @@ asgiref==3.6.0
     # via django
 beautifulsoup4==4.9.3
     # via wagtail
-billiard==3.6.4.0
+billiard==4.2.0
     # via celery
 boto3==1.26.114
     # via newamerica-cms (pyproject.toml)
@@ -20,7 +20,7 @@ cairocffi==1.5.0
     #   weasyprint
 cairosvg==2.7.0
     # via weasyprint
-celery==4.4.7
+celery==5.4.0
     # via newamerica-cms (pyproject.toml)
 certifi==2022.12.7
     # via requests
@@ -30,6 +30,18 @@ cffi==1.15.1
     #   weasyprint
 charset-normalizer==3.1.0
     # via requests
+click==8.1.7
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
 createsend==7.0.0
     # via newamerica-cms (pyproject.toml)
 cssselect2==0.7.0
@@ -117,7 +129,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-kombu==4.6.11
+kombu==5.3.7
     # via celery
 l18n==2021.3
     # via wagtail
@@ -132,6 +144,8 @@ pillow==9.5.0
     #   wagtail
 pillow-heif==0.14.0
     # via willow
+prompt-toolkit==3.0.43
+    # via click-repl
 psycopg2==2.9.6
     # via newamerica-cms (pyproject.toml)
 pycparser==2.21
@@ -141,12 +155,12 @@ pyphen==0.14.0
 python-dateutil==2.8.2
     # via
     #   botocore
+    #   celery
     #   faker
 python-docx==0.8.11
     # via newamerica-cms (pyproject.toml)
 pytz==2023.3
     # via
-    #   celery
     #   django
     #   django-modelcluster
     #   djangorestframework
@@ -184,15 +198,18 @@ tinycss2==1.2.1
     #   weasyprint
 typing-extensions==4.5.0
     # via dj-database-url
+tzdata==2024.1
+    # via celery
 urllib3==1.26.15
     # via
     #   botocore
     #   elasticsearch
     #   requests
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
 wagtail==5.2.2
     # via
     #   newamerica-cms (pyproject.toml)
@@ -204,6 +221,8 @@ wagtail-headless-preview==0.7.0
     # via newamerica-cms (pyproject.toml)
 wand==0.6.11
     # via newamerica-cms (pyproject.toml)
+wcwidth==0.2.13
+    # via prompt-toolkit
 weasyprint==51
     # via newamerica-cms (pyproject.toml)
 webencodings==0.5.1
@@ -214,7 +233,9 @@ webencodings==0.5.1
 whitenoise==6.4.0
     # via newamerica-cms (pyproject.toml)
 willow[heif]==1.6.2
-    # via wagtail
+    # via
+    #   wagtail
+    #   willow
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==67.6.1

--- a/requirements/local-dev.txt
+++ b/requirements/local-dev.txt
@@ -1,4 +1,4 @@
-amqp==2.6.1
+amqp==5.2.0
     # via kombu
 anyascii==0.3.2
     # via wagtail
@@ -8,7 +8,7 @@ bcrypt==4.0.1
     # via paramiko
 beautifulsoup4==4.9.3
     # via wagtail
-billiard==3.6.4.0
+billiard==4.2.0
     # via celery
 black==23.10.1
     # via newamerica-cms (pyproject.toml)
@@ -24,7 +24,7 @@ cairocffi==1.5.0
     #   weasyprint
 cairosvg==2.7.0
     # via weasyprint
-celery==4.4.7
+celery==5.4.0
     # via newamerica-cms (pyproject.toml)
 certifi==2022.12.7
     # via requests
@@ -37,7 +37,18 @@ cffi==1.15.1
 charset-normalizer==3.1.0
     # via requests
 click==8.1.7
-    # via black
+    # via
+    #   black
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
 createsend==7.0.0
     # via newamerica-cms (pyproject.toml)
 cryptography==40.0.2
@@ -131,7 +142,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-kombu==4.6.11
+kombu==5.3.7
     # via celery
 l18n==2021.3
     # via wagtail
@@ -158,6 +169,8 @@ pillow-heif==0.14.0
     # via willow
 platformdirs==3.11.0
     # via black
+prompt-toolkit==3.0.43
+    # via click-repl
 psycopg2==2.9.6
     # via newamerica-cms (pyproject.toml)
 pycparser==2.21
@@ -169,12 +182,12 @@ pyphen==0.14.0
 python-dateutil==2.8.2
     # via
     #   botocore
+    #   celery
     #   faker
 python-docx==0.8.11
     # via newamerica-cms (pyproject.toml)
 pytz==2023.3
     # via
-    #   celery
     #   django
     #   django-modelcluster
     #   djangorestframework
@@ -219,15 +232,18 @@ typing-extensions==4.5.0
     # via
     #   black
     #   dj-database-url
+tzdata==2024.1
+    # via celery
 urllib3==1.26.15
     # via
     #   botocore
     #   elasticsearch
     #   requests
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
 wagtail==5.2.2
     # via
     #   newamerica-cms (pyproject.toml)
@@ -239,6 +255,8 @@ wagtail-headless-preview==0.7.0
     # via newamerica-cms (pyproject.toml)
 wand==0.6.11
     # via newamerica-cms (pyproject.toml)
+wcwidth==0.2.13
+    # via prompt-toolkit
 weasyprint==51
     # via newamerica-cms (pyproject.toml)
 webencodings==0.5.1
@@ -249,7 +267,9 @@ webencodings==0.5.1
 whitenoise==6.4.0
     # via newamerica-cms (pyproject.toml)
 willow[heif]==1.6.2
-    # via wagtail
+    # via
+    #   wagtail
+    #   willow
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==67.6.1


### PR DESCRIPTION
This draft pull request should not be merged yet. It is unfinished and requires some more work on the Amazon Elastic Beanstalk (EB) environment and configuration before it will, in addition to other potential code changes to this repo.

Some changes so far (see individual commits for more detail):
* EB environment setup (ignore files, extension file settings for configuring the base machine's packages and the settings for our actual WSGI process).
* Adding an `eb_production.py` file which mimics our production settings with EB-specific changes. If/when we decide to run the actual site on EB, these settings should probably find their way into the regular production/dev settings files as necessary and the `eb_` prefixed file removed.

I've been attempting to get this branch running on EB using the [command line tool](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html) and running some commands. These commands often call for an environment name, and the one I'm using is `newamerica-cms-dev`.

* `eb console` -- opens the web page for the stats and configuration of the environment.
* `eb deploy <environment name>` -- deploys the current state of the source tree to the environment. When you make changes to the code, whether or not they're committed in git, this command will send those to EB to try and run
* `eb logs <environment name>` -- shows the logs for the environment. Sometimes, this commands fails for me with a 400 error, which is weird since the thing issuing the request is also created by Amazon. In those cases, sometimes the logs are available on the `eb console` page (sometimes they aren't though).
* `eb open <environment name>` -- opens URL that the environment is running on. This should be the actual wagtail instance URL. But I haven't gotten it to actually load anything beyond an error page because the configuration isn't correct yet.

The current state of the `newamerica-cms-dev` environment is: the console says it's "ok" but the site won't load and I can't add a database (from the left sidebar of the console's Configuration option, then Networking and Databases) without getting these errors:

> Service:AmazonCloudFormation, Message:Stack named 'awseb-e-mqm28pkquz-stack' aborted operation. Current state: 'UPDATE_ROLLBACK_COMPLETE' Reason: null
> Creating RDS database security group named: awseb-e-mqm28pkquz-stack-awsebrdsdbsecuritygroup-ox7kcrhn7822 failed Reason: Internal Failure

My current theory is that creating the database also creates an RDS security group, but the user I'm running as might not have permission to do so. I can't confirm this though, and I've poked around in the users and permissions areas of AWS and not found anything obviously helpful.