### PR TITLE
Fix: Support external links for homepage lead stories

### DIFF
--- a/newamericadotorg/templates/components/card_lg.html
+++ b/newamericadotorg/templates/components/card_lg.html
@@ -23,9 +23,9 @@
         </h2>
 
         {# Description #}
-        {% if post.story_excerpt or post.search_description or post.subheading %}
+        {% if post.story_excerpt or post.search_description or post.subheading or post.description %}
           <h6 class="card__text__subtitle margin-10">
-            {% firstof post.story_excerpt post.search_description post.subheading %}
+            {% firstof post.story_excerpt post.search_description post.subheading post.description %}
           </h6>
         {% endif %}
 


### PR DESCRIPTION
Related to: #1877

Display external links' descriptions when used in large cards.