### PR TITLE
Bump celery version

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py migrate
 web: gunicorn newamericadotorg.wsgi --log-file -
-worker: celery worker --app=newamericadotorg.celery.app --loglevel=INFO
+worker: celery --app=newamericadotorg.celery.app --loglevel=INFO worker

--- a/ci.txt
+++ b/ci.txt
@@ -2,35 +2,33 @@ amqp==5.3.1
     # via kombu
 anyascii==0.3.2
     # via wagtail
-asgiref==3.6.0
+asgiref==3.8.1
     # via django
-beautifulsoup4==4.9.3
+beautifulsoup4==4.11.2
     # via wagtail
 billiard==4.2.1
     # via celery
-boto3==1.26.114
+boto3==1.35.11
     # via newamerica-cms (pyproject.toml)
-botocore==1.29.114
+botocore==1.35.11
     # via
     #   boto3
     #   s3transfer
-cairocffi==1.5.0
+cairocffi==1.7.1
     # via
     #   cairosvg
     #   weasyprint
-cairosvg==2.7.0
+cairosvg==2.7.1
     # via weasyprint
 celery==5.4.0
     # via newamerica-cms (pyproject.toml)
-certifi==2022.12.7
-    # via
-    #   requests
-    #   sentry-sdk
-cffi==1.15.1
+certifi==2024.8.30
+    # via requests
+cffi==1.17.0
     # via
     #   cairocffi
     #   weasyprint
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.8
     # via
@@ -54,7 +52,7 @@ defusedxml==0.7.1
     #   willow
 dj-database-url==1.3.0
     # via newamerica-cms (pyproject.toml)
-django==3.2.18
+django==3.2.25
     # via
     #   dj-database-url
     #   django-anymail
@@ -73,39 +71,39 @@ django==3.2.18
     #   djangorestframework
     #   newamerica-cms (pyproject.toml)
     #   wagtail
-django-anymail==9.1
+django-anymail==9.2
     # via newamerica-cms (pyproject.toml)
-django-appconf==1.0.5
+django-appconf==1.0.6
     # via django-compressor
-django-basic-auth-ip-whitelist==0.5
+django-basic-auth-ip-whitelist==0.6.0
     # via newamerica-cms (pyproject.toml)
-django-compressor==4.3.1
+django-compressor==4.4
     # via newamerica-cms (pyproject.toml)
 django-cors-headers==3.14.0
     # via newamerica-cms (pyproject.toml)
-django-csp==3.7
+django-csp==3.8
     # via newamerica-cms (pyproject.toml)
 django-filter==23.5
     # via
     #   newamerica-cms (pyproject.toml)
     #   wagtail
-django-modelcluster==6.1
+django-modelcluster==6.3
     # via
     #   newamerica-cms (pyproject.toml)
     #   wagtail
-django-multiselectfield==0.1.12
+django-multiselectfield==0.1.13
     # via newamerica-cms (pyproject.toml)
 django-permissionedforms==0.1
     # via wagtail
-django-redis==5.2.0
+django-redis==5.4.0
     # via newamerica-cms (pyproject.toml)
-django-storages==1.13.2
+django-storages==1.14.4
     # via newamerica-cms (pyproject.toml)
-django-taggit==2.1.0
+django-taggit==4.0.0
     # via wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7.1
     # via wagtail
-djangorestframework==3.14.0
+djangorestframework==3.15.1
     # via wagtail
 draftjs-exporter==2.1.7
     # via wagtail
@@ -113,6 +111,8 @@ elasticsearch==5.5.3
     # via newamerica-cms (pyproject.toml)
 et-xmlfile==1.1.0
     # via openpyxl
+faker==18.13.0
+    # via newamerica-cms (pyproject.toml)
 filetype==1.2.0
     # via willow
 gunicorn==20.0.4
@@ -121,7 +121,7 @@ html5lib==1.1
     # via
     #   wagtail
     #   weasyprint
-idna==3.4
+idna==3.8
     # via requests
 jmespath==1.0.1
     # via
@@ -131,36 +131,36 @@ kombu==5.4.2
     # via celery
 l18n==2021.3
     # via wagtail
-lxml==4.9.2
+lxml==5.3.0
     # via python-docx
-openpyxl==3.1.2
+openpyxl==3.1.5
     # via wagtail
-pillow==9.5.0
+pillow==10.4.0
     # via
     #   cairosvg
     #   pillow-heif
     #   wagtail
-pillow-heif==0.14.0
+pillow-heif==0.18.0
     # via willow
 prompt-toolkit==3.0.50
     # via click-repl
-psycopg2==2.9.6
+psycopg2==2.9.9
     # via newamerica-cms (pyproject.toml)
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyphen==0.14.0
+pyphen==0.16.0
     # via weasyprint
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   celery
-python-docx==0.8.11
+    #   faker
+python-docx==1.1.2
     # via newamerica-cms (pyproject.toml)
-pytz==2023.3
+pytz==2024.1
     # via
     #   django
     #   django-modelcluster
-    #   djangorestframework
     #   l18n
 rcssmin==1.1.1
     # via django-compressor
@@ -168,59 +168,59 @@ redis==3.5.3
     # via
     #   django-redis
     #   newamerica-cms (pyproject.toml)
-requests==2.28.2
+requests==2.32.3
     # via
     #   django-anymail
     #   wagtail
 rjsmin==1.2.1
     # via django-compressor
-s3transfer==0.6.0
+s3transfer==0.10.2
     # via boto3
-sentry-sdk==1.19.1
-    # via newamerica-cms (pyproject.toml)
 six==1.16.0
     # via
     #   html5lib
     #   l18n
     #   python-dateutil
-soupsieve==2.4
+soupsieve==2.6
     # via beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.5.1
     # via django
-telepath==0.3
+telepath==0.3.1
     # via wagtail
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via
     #   cairosvg
     #   cssselect2
     #   weasyprint
-typing-extensions==4.5.0
-    # via dj-database-url
+typing-extensions==4.12.2
+    # via
+    #   asgiref
+    #   dj-database-url
+    #   python-docx
 tzdata==2025.1
     # via
     #   celery
     #   kombu
-urllib3==1.26.15
+urllib3==2.2.2
     # via
     #   botocore
     #   elasticsearch
     #   requests
-    #   sentry-sdk
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wagtail==5.2.2
+wagtail==5.2.6
     # via
     #   newamerica-cms (pyproject.toml)
     #   wagtail-autocomplete
     #   wagtail-headless-preview
-wagtail-autocomplete==0.10.0
+wagtail-autocomplete==0.11.0
     # via newamerica-cms (pyproject.toml)
 wagtail-headless-preview==0.7.0
     # via newamerica-cms (pyproject.toml)
-wand==0.6.11
+wand==0.6.13
     # via newamerica-cms (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -231,13 +231,13 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-whitenoise==6.4.0
+whitenoise==6.7.0
     # via newamerica-cms (pyproject.toml)
-willow[heif]==1.6.2
+willow[heif]==1.6.3
     # via wagtail
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==67.6.1
+setuptools==74.1.1
     # via
     #   gunicorn
     #   weasyprint

--- a/local-dev.txt
+++ b/local-dev.txt
@@ -2,38 +2,43 @@ amqp==5.3.1
     # via kombu
 anyascii==0.3.2
     # via wagtail
-asgiref==3.6.0
+asgiref==3.8.1
     # via django
-beautifulsoup4==4.9.3
+bcrypt==4.2.1
+    # via paramiko
+beautifulsoup4==4.11.2
     # via wagtail
 billiard==4.2.1
     # via celery
-boto3==1.26.114
+black==25.1.0
     # via newamerica-cms (pyproject.toml)
-botocore==1.29.114
+boto3==1.36.13
+    # via newamerica-cms (pyproject.toml)
+botocore==1.36.13
     # via
     #   boto3
     #   s3transfer
-cairocffi==1.5.0
+cairocffi==1.7.1
     # via
     #   cairosvg
     #   weasyprint
-cairosvg==2.7.0
+cairosvg==2.7.1
     # via weasyprint
 celery==5.4.0
     # via newamerica-cms (pyproject.toml)
-certifi==2022.12.7
-    # via
-    #   requests
-    #   sentry-sdk
-cffi==1.15.1
+certifi==2025.1.31
+    # via requests
+cffi==1.17.1
     # via
     #   cairocffi
+    #   cryptography
+    #   pynacl
     #   weasyprint
-charset-normalizer==3.1.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
+    #   black
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -44,6 +49,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
+cryptography==44.0.0
+    # via paramiko
 cssselect2==0.7.0
     # via
     #   cairosvg
@@ -54,7 +61,7 @@ defusedxml==0.7.1
     #   willow
 dj-database-url==1.3.0
     # via newamerica-cms (pyproject.toml)
-django==3.2.18
+django==3.2.25
     # via
     #   dj-database-url
     #   django-anymail
@@ -73,46 +80,50 @@ django==3.2.18
     #   djangorestframework
     #   newamerica-cms (pyproject.toml)
     #   wagtail
-django-anymail==9.1
+django-anymail==9.2
     # via newamerica-cms (pyproject.toml)
-django-appconf==1.0.5
+django-appconf==1.0.6
     # via django-compressor
-django-basic-auth-ip-whitelist==0.5
+django-basic-auth-ip-whitelist==0.6.0
     # via newamerica-cms (pyproject.toml)
-django-compressor==4.3.1
+django-compressor==4.4
     # via newamerica-cms (pyproject.toml)
 django-cors-headers==3.14.0
     # via newamerica-cms (pyproject.toml)
-django-csp==3.7
+django-csp==3.8
     # via newamerica-cms (pyproject.toml)
 django-filter==23.5
     # via
     #   newamerica-cms (pyproject.toml)
     #   wagtail
-django-modelcluster==6.1
+django-modelcluster==6.3
     # via
     #   newamerica-cms (pyproject.toml)
     #   wagtail
-django-multiselectfield==0.1.12
+django-multiselectfield==0.1.13
     # via newamerica-cms (pyproject.toml)
 django-permissionedforms==0.1
     # via wagtail
-django-redis==5.2.0
+django-redis==5.4.0
     # via newamerica-cms (pyproject.toml)
-django-storages==1.13.2
+django-storages==1.14.4
     # via newamerica-cms (pyproject.toml)
-django-taggit==2.1.0
+django-taggit==4.0.0
     # via wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7.1
     # via wagtail
-djangorestframework==3.14.0
+djangorestframework==3.15.1
     # via wagtail
 draftjs-exporter==2.1.7
     # via wagtail
 elasticsearch==5.5.3
     # via newamerica-cms (pyproject.toml)
-et-xmlfile==1.1.0
+et-xmlfile==2.0.0
     # via openpyxl
+fabric==2.7.1
+    # via newamerica-cms (pyproject.toml)
+faker==18.13.0
+    # via newamerica-cms (pyproject.toml)
 filetype==1.2.0
     # via willow
 gunicorn==20.0.4
@@ -121,8 +132,10 @@ html5lib==1.1
     # via
     #   wagtail
     #   weasyprint
-idna==3.4
+idna==3.10
     # via requests
+invoke==1.7.3
+    # via fabric
 jmespath==1.0.1
     # via
     #   boto3
@@ -131,36 +144,50 @@ kombu==5.4.2
     # via celery
 l18n==2021.3
     # via wagtail
-lxml==4.9.2
+lxml==5.3.0
     # via python-docx
-openpyxl==3.1.2
+mypy-extensions==1.0.0
+    # via black
+openpyxl==3.1.5
     # via wagtail
-pillow==9.5.0
+packaging==24.2
+    # via black
+paramiko==3.5.1
+    # via fabric
+pathlib2==2.3.7.post1
+    # via fabric
+pathspec==0.12.1
+    # via black
+pillow==10.4.0
     # via
     #   cairosvg
     #   pillow-heif
     #   wagtail
-pillow-heif==0.14.0
+pillow-heif==0.21.0
     # via willow
+platformdirs==4.3.6
+    # via black
 prompt-toolkit==3.0.50
     # via click-repl
-psycopg2==2.9.6
+psycopg2==2.9.10
     # via newamerica-cms (pyproject.toml)
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyphen==0.14.0
+pynacl==1.5.0
+    # via paramiko
+pyphen==0.17.2
     # via weasyprint
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   celery
-python-docx==0.8.11
+    #   faker
+python-docx==1.1.2
     # via newamerica-cms (pyproject.toml)
-pytz==2023.3
+pytz==2025.1
     # via
     #   django
     #   django-modelcluster
-    #   djangorestframework
     #   l18n
 rcssmin==1.1.1
     # via django-compressor
@@ -168,59 +195,65 @@ redis==3.5.3
     # via
     #   django-redis
     #   newamerica-cms (pyproject.toml)
-requests==2.28.2
+requests==2.32.3
     # via
     #   django-anymail
     #   wagtail
 rjsmin==1.2.1
     # via django-compressor
-s3transfer==0.6.0
-    # via boto3
-sentry-sdk==1.19.1
+ruff==0.9.4
     # via newamerica-cms (pyproject.toml)
-six==1.16.0
+s3transfer==0.11.2
+    # via boto3
+six==1.17.0
     # via
     #   html5lib
     #   l18n
+    #   pathlib2
     #   python-dateutil
-soupsieve==2.4
+soupsieve==2.6
     # via beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.5.3
     # via django
-telepath==0.3
+telepath==0.3.1
     # via wagtail
-tinycss2==1.2.1
+tinycss2==1.4.0
     # via
     #   cairosvg
     #   cssselect2
     #   weasyprint
-typing-extensions==4.5.0
-    # via dj-database-url
+tomli==2.2.1
+    # via black
+typing-extensions==4.12.2
+    # via
+    #   asgiref
+    #   black
+    #   dj-database-url
+    #   python-docx
 tzdata==2025.1
     # via
     #   celery
     #   kombu
-urllib3==1.26.15
+urllib3==2.3.0
     # via
     #   botocore
     #   elasticsearch
     #   requests
-    #   sentry-sdk
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wagtail==5.2.2
+wagtail==5.2.8
     # via
     #   newamerica-cms (pyproject.toml)
     #   wagtail-autocomplete
     #   wagtail-headless-preview
-wagtail-autocomplete==0.10.0
+wagtail-autocomplete==0.11.0
     # via newamerica-cms (pyproject.toml)
 wagtail-headless-preview==0.7.0
     # via newamerica-cms (pyproject.toml)
-wand==0.6.11
+wand==0.6.13
     # via newamerica-cms (pyproject.toml)
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -231,13 +264,13 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-whitenoise==6.4.0
+whitenoise==6.8.2
     # via newamerica-cms (pyproject.toml)
-willow[heif]==1.6.2
+willow[heif]==1.6.3
     # via wagtail
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==67.6.1
+setuptools==75.8.0
     # via
     #   gunicorn
     #   weasyprint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # Django related
     'Django >= 3.2.6, < 4',
     'Wagtail >= 5.2.2, < 5.3',
-    'Celery >= 4.4, < 5.0',
+    'Celery >= 5.4, < 5.5',
     'dj-database-url >= 1.3.0, < 2',
     'django-cors-headers >= 3.13.0, < 4',
     'django-storages >= 1.13, < 2',


### PR DESCRIPTION
Trying to deploy https://github.com/newamericafoundation/newamerica-cms/pull/1880 to Heroku failed with an error

```       ERROR: No matching distribution found for celery==4.4.7
 !     Error: One of your dependencies contains broken metadata.
 !     
 !     Newer versions of pip reject packages that use invalid versions
 !     in their metadata (such as Celery older than v5.2.1).
 !     
 !     Try upgrading to a newer version of the affected package.
 !     
 !     For more help, see:
 !     https://devcenter.heroku.com/changelog-items/3073
 !     Error: Unable to install dependencies using pip.
 !     
 !     See the log output above for more information.
```

This is because the Heroku builder uses an updated version of `pip` which is more strict about broken metadata in older packages.

While we could find an alternative approach to building the app (with an older version of `pip`), having reviewed the breaking changes in Celery releases up to latest, I can't see anything (other than the change to the `Procfile` addressed in this PR) that would cause issues.

Bumping the version fixes the issue and should enable us to deploy successfully. We can test Celery behaviour on staging before promoting to production.