### PR TITLE
Remove Shorthand when navigating between report sections

### DIFF
--- a/newamericadotorg/assets/react/report/components/Body.js
+++ b/newamericadotorg/assets/react/report/components/Body.js
@@ -108,6 +108,11 @@ class Body extends Component {
       prevProps.section.number != this.props.section.number &&
       this.props.section
     ) {
+      // When the section changes, remove the Shorthand embed,
+      // allowing it to reinitialize when navigated back to the page.
+      if (window.Shorthand) {
+        window.Shorthand.remove();
+      };
       this.citationEvents();
       this.loadScripts();
       this.props.dispatch({


### PR DESCRIPTION
This change removes the Shorthand visualisation when navigating between report sections, which allows the Shorthand embed code to re-render the embed when the page is loaded again.